### PR TITLE
removing 'the' from main content header

### DIFF
--- a/app/jsx/layouts/DepartmentLayout.jsx
+++ b/app/jsx/layouts/DepartmentLayout.jsx
@@ -89,7 +89,7 @@ class DepartmentLayout extends React.Component {
           <main id="maincontent">
             <section className="o-columnbox1">
               <header>
-                <h2>Works by the {this.props.unit.name}</h2>
+                <h2>Works by {this.props.unit.name}</h2>
               </header>
               <div className="c-itemactions">
                 <ShareComp type="unit" id={this.props.unit.id} />


### PR DESCRIPTION
it's duplicative for units that include 'the' in their unit name