### PR TITLE
Remove eScholarship string from citation_title meta tag

### DIFF
--- a/app/jsx/components/MetaTagsComp.jsx
+++ b/app/jsx/components/MetaTagsComp.jsx
@@ -19,8 +19,6 @@ export default class MetaTagsComp extends React.Component
   render() {
     let finalTitle = this.props.title ? this.stripHtml(this.props.title) : "eScholarship"
     let descrip = this.props.descrip ? this.stripHtml(this.props.descrip) : ''
-    if (finalTitle.indexOf("eScholarship") < 0)
-      finalTitle = finalTitle + " - eScholarship"
     return (
       <MetaTags>
         <title>{finalTitle}</title>


### PR DESCRIPTION
Tested this locally and it fixes the issue