### PR TITLE
Modifying main content heading for units

### DIFF
--- a/app/jsx/layouts/DepartmentLayout.jsx
+++ b/app/jsx/layouts/DepartmentLayout.jsx
@@ -89,7 +89,7 @@ class DepartmentLayout extends React.Component {
           <main id="maincontent">
             <section className="o-columnbox1">
               <header>
-                <h2>Works by {this.props.unit.name}</h2>
+                <h2>{this.props.unit.name} Works</h2>
               </header>
               <div className="c-itemactions">
                 <ShareComp type="unit" id={this.props.unit.id} />


### PR DESCRIPTION
"Works by" language was problematic since some units post content that they or their researchers didn't write themselves (e.g. sponsored content). Solution for now is to append "Works" to the end of the unit name, and think of a better solution later.