### PR TITLE
Additional change to 'Works' labeling

### DIFF
--- a/app/jsx/layouts/DepartmentLayout.jsx
+++ b/app/jsx/layouts/DepartmentLayout.jsx
@@ -89,7 +89,7 @@ class DepartmentLayout extends React.Component {
           <main id="maincontent">
             <section className="o-columnbox1">
               <header>
-                <h2>{this.props.unit.name} Works</h2>
+                <h2>{this.props.unit.name}</h2>
               </header>
               <div className="c-itemactions">
                 <ShareComp type="unit" id={this.props.unit.id} />


### PR DESCRIPTION
CM has identified a case where our new 'Works' / 'Works by' strategy isn't working, so we're just nixing the label altogether until we can figure out something that works universally.