### PR TITLE
Enabling HTML for Issue Description

### DIFF
--- a/app/jsx/components/IssueComp.jsx
+++ b/app/jsx/components/IssueComp.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import LazyImageComp from '../components/LazyImageComp.jsx'
+import ArbitraryHTMLComp from "../components/ArbitraryHTMLComp.jsx"
 
 class IssueComp extends React.Component {
   render() {
@@ -20,7 +21,7 @@ class IssueComp extends React.Component {
         </figure>
       }
         <div className="c-issue__description">
-          <p>{p.description}</p>
+          <ArbitraryHTMLComp html={p.description} h1Level={3}/>
         </div>
       </div>
     )


### PR DESCRIPTION
I cribbed from a similar fix in one of MH's branches (https://github.com/eScholarship/jschol/commit/4b1d1d9bd85e20303e3aefbfa0beeba9f49073ab) so it's entirely possible I missed something... but the goal was to render HTML (if present) in the Issue Description that editors provide in OJS.