### PR TITLE
OA Policy stats page label change

### DIFF
--- a/app/statsPages.rb
+++ b/app/statsPages.rb
@@ -771,7 +771,7 @@ def unitStats_deposits_by_oa(unitID)
   }.unindent, queryParams)
   DB.fetch(query).each { |row|
     yrmo = row[:yr].to_i*100 + row[:mo].to_i
-    posts['OA related'][yrmo] += row[:ct]
+    posts['OA policy related'][yrmo] += row[:ct]
     posts['other'][yrmo] -= row[:ct]
   }
 


### PR DESCRIPTION
Per CM's request in #pub_sc, changing label of the 'OA related' category to 'OA policy related'
(hopefully without breaking anything)