### PR TITLE
Issue caption More button 'display: none' is unnecessary, as truncati…

### DIFF
--- a/app/jsx/components/IssueComp.jsx
+++ b/app/jsx/components/IssueComp.jsx
@@ -30,7 +30,7 @@ class IssueComp extends React.Component {
          after: '.c-issue__caption-truncate-more',
          callback: () => $(this.caption).find(".c-issue__caption-truncate-more").click(this.openAndAdjust)
       });
-      setTimeout(() => $(this.caption).trigger('update'), 0) // removes 'more' link upon page load if less than truncation threshold
+      setTimeout(() => $(this.caption).trigger('update'), 0) // removes 'more' link upon page load if less than truncation threshold (max-height), or if no max-height is applied (mobile)
     }
     if (!(this.thumbnail)) { this.handleMissingThumbnail() }
   }

--- a/app/scss/_clientmarkup.scss
+++ b/app/scss/_clientmarkup.scss
@@ -27,7 +27,16 @@
   // ***** Links ***** //
 
   a {
+    // ToDo: This is similar to c-pubinfo__link...
+    //  It might make sense to create an object with this wrapping property,
+    //  but maybe something to change once we have a regession testing suite.
     @extend %o-textlink__secondary;
+    @include u-one-line-truncation(active);
+
+    @include bp(screen1) {
+      @include u-one-line-truncation(inactive);
+      @include u-overflow-wrap();
+    }
   }
 
   // ***** Lists ***** //

--- a/app/scss/_issue.scss
+++ b/app/scss/_issue.scss
@@ -78,7 +78,7 @@
 // Button to show untruncated text:
 .c-issue__caption-truncate-more {
   @extend %o-button__7;
-  display: none;
+  // "display: none"  is unnecessary, as truncation doesn't get triggered at this screen size.
 
   @include bp(screen1) {
     display: contents;

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "flickity-imagesloaded": "^2.0.0",
     "intersection-observer": "^0.4.3",
     "jquery": "^3.2.1",
-    "jquery.dotdotdot": "amywieliczka/jQuery.dotdotdot",
+    "jquery.dotdotdot": "amywieliczka/jQuery.dotdotdot#4f7d03a442ceca0b75a2fb641a065e47297d5666",
     "lodash": "^4.17.4",
     "lozad": "^1.0.9",
     "prop-types": "^15.5.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5563,7 +5563,7 @@ jpegtran-bin@^3.0.0:
     bin-wrapper "^3.0.0"
     logalot "^2.0.0"
 
-jquery.dotdotdot@amywieliczka/jQuery.dotdotdot:
+jquery.dotdotdot@amywieliczka/jQuery.dotdotdot#4f7d03a442ceca0b75a2fb641a065e47297d5666:
   version "1.8.3"
   resolved "https://codeload.github.com/amywieliczka/jQuery.dotdotdot/tar.gz/4f7d03a442ceca0b75a2fb641a065e47297d5666"
 


### PR DESCRIPTION
…on doesn't get triggered at mobile size; Links under c-clientmarkup element now wrap if they need to