### PR TITLE
Links under clientmarkup don't need 'u-one-line-truncation' mixin

### DIFF
--- a/app/eschol-ui.version
+++ b/app/eschol-ui.version
@@ -853,5 +853,19 @@ Lots of stuff modified.
   modified:   app/jsx/components/IssueComp.jsx
   modified:   app/scss/_issue.scss
 
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+>>> 95c0937e0d91a4cdcb7534f88853c127967dc4df, 2018-10-24        <<<
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+  added: app/jsx/components/SocialFeedComp.jsx
+  added: app/scss/_socialfeed.scss
+  modified: app/scss/_issue.scss
+  modified: app/scss/_clientmarkup.scss
+
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+>>> 65d91bcb0dfdc505560a09893e86fd9443182007, 2018-11-13        <<<
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+  modified: app/scss/_clientmarkup.scss
 
 

--- a/app/scss/_clientmarkup.scss
+++ b/app/scss/_clientmarkup.scss
@@ -27,14 +27,10 @@
   // ***** Links ***** //
 
   a {
-    // ToDo: This is similar to c-pubinfo__link...
-    //  It might make sense to create an object with this wrapping property,
-    //  but maybe something to change once we have a regession testing suite.
+    // Similar to c-pubinfo__link, but without the u-one-line-truncation mixin
     @extend %o-textlink__secondary;
-    @include u-one-line-truncation(active);
 
     @include bp(screen1) {
-      @include u-one-line-truncation(inactive);
       @include u-overflow-wrap();
     }
   }


### PR DESCRIPTION
Fixes this problem: https://www.pivotaltracker.com/story/show/161941746