### PR TITLE
Redirect old CloudFront URLs to just plain escholarship.org. 

### DIFF
--- a/app/redirect.rb
+++ b/app/redirect.rb
@@ -38,11 +38,14 @@ def checkRedirect(origURI)
            "eprints.cdlib.org",
            "escholarship.cdlib.org", "www.escholarship.cdlib.org",
            "escholarship-s10.cdlib.org", "www.escholarship-s8.cdlib.org",
-           "escholarship.ucop.edu"
+           "escholarship.ucop.edu", "cloudfront.escholarship.org",
+           "pub-jschol-prd.escholarship.org"
           ].include?(uri.host)
       uri.host = "escholarship.org"
     elsif uri.path =~ %r{^/uc/item/(\w+)(.*)}
       uri = handleItemRedirect(uri, $1, $2)
+    elsif uri.path =~ %r{^/dist/prd/(.*)}
+      uri.path = "/#{$1}"  # old CloudFront URLs
     elsif uri.path =~ %r{^/uc/search} &&
           !(uri.query =~ %r{smode=(pmid|PR|postprintReport|repec|bpList|eeList|etdLinks)\b})
       uri = handleSearchRedirect(uri)

--- a/test/testRedirects.rb
+++ b/test/testRedirects.rb
@@ -40,6 +40,13 @@ def testRedirect(fromURL, toURL)
   end
 end
 
+# Redirect old CloudFront URLs
+testRedirect("http://cloudfront.escholarship.org/dist/prd/content/qt5563x8nf/qt5563x8nf.pdf?t=mpqhzr&v=lg",
+             "http://escholarship.org/content/qt5563x8nf/qt5563x8nf.pdf?t=mpqhzr&v=lg")
+
+# Redirect alias of old load balancer
+testRedirect("http://pub-jschol-prd.escholarship.org/ucoapolicies", "http://escholarship.org/ucoapolicies")
+
 # Redirect escholarship.ucop.edu to eschol
 testRedirect("http://escholarship.ucop.edu/uc/ucpress", "http://escholarship.org/uc/ucpress")
 


### PR DESCRIPTION
…'re at it, redirect pub-jschol-prd URLs also.