### PR TITLE
Removing entire 'Citation' level from Download Menu

### DIFF
--- a/app/jsx/components/ItemActionsComp.jsx
+++ b/app/jsx/components/ItemActionsComp.jsx
@@ -56,15 +56,15 @@ class Downloadable extends React.Component {
                 </ul>
               </li>
             }
-              <li className="o-download__nested-list2">
+              {/*    <li className="o-download__nested-list2">
                 Citation
                 <ul>
-          {/*     <li><NotYetLink element="a">RIS</NotYetLink></li>
-                  <li><NotYetLink element="a">BibText</NotYetLink></li>   */}
+               <li><NotYetLink element="a">RIS</NotYetLink></li>
+                  <li><NotYetLink element="a">BibText</NotYetLink></li>   
                   <li><NotYetLink element="a">EndNote</NotYetLink></li>
-          {/*     <li><NotYetLink element="a">RefWorks</NotYetLink></li>  */}
+               <li><NotYetLink element="a">RefWorks</NotYetLink></li> 
                 </ul>
-              </li>
+              </li> */}
           {/* p.attrs.supp_files &&
               <li className="o-download__nested-list3">
                 Supplemental Material


### PR DESCRIPTION
Other as of yet unsupported reference links in the download menu were already commented out, but EndNote wasn't and needed to be. Removing entire section until we're ready to implement these.