### PR TITLE
Add an exception for help.escholarship.org links

### DIFF
--- a/app/jsx/objects/trumbowyg.fancyCreateLink.jsx
+++ b/app/jsx/objects/trumbowyg.fancyCreateLink.jsx
@@ -64,7 +64,7 @@
 
                 t.openModalInsert(t.lang.createLink, options, function (v) { // v is value
                     // Make escholarship.org links root-relative
-                    var url = v.url.replace(/http(s?):\/\/[^/]*escholarship.org/, '')
+                    var url = v.url.replace(/http(s?):\/\/(?!help\.)[^/]*escholarship.org/, '')
                     if (!url.length) {
                         return false;
                     }


### PR DESCRIPTION
- Revise the Trumbowyg.fancyCreateLink function to add an exception for
help.escholarship.org links.