### PR TITLE
PT-172061580 Add a fix for garbled UTF-8 characters to convert.rb

### DIFF
--- a/tools/convert.rb
+++ b/tools/convert.rb
@@ -698,6 +698,8 @@ def generatePdfTOC(itemID)
     divs = []
     buf = ""
     outline.each { |line|
+      # handle garbled UTF-8 strings courtesty of mutools ( see https://bugs.ghostscript.com/show_bug.cgi?id=702358 )
+      line.gsub!(/\\x([CDEF][0-9A-F])\\x([89AB][0-9A-F])/) { [Regexp.last_match[1].to_i(16), Regexp.last_match[2].to_i(16)].pack("c*").force_encoding('UTF-8') }
       if line =~ /\t#/
         (buf+line) =~ /^[^\t]?(\t*)"([^\t]*)"\t#(\d+)/ or raise("can't parse TOC line: #{line.inspect}")
         divs << { level: $1.length, title: $2.strip, anchor: "page=#{$3.to_i}" }


### PR DESCRIPTION
* Add a workaround for [a bug in mutool](https://bugs.ghostscript.com/show_bug.cgi?id=702358)
which produces two-digit hex escape strings instead of UTF-8 characters
* This workaround uses a gsub method (which is a destructive regex) and
forces encoding to UTF-8
* This gsub line is the work of @martinhaye he deserves all the credit
in writing it.