### PR TITLE
remove null keys from .lando.yml

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -4,7 +4,6 @@ name: jschol
 env_file:
   - defaults.env
   - local.env
-keys:
 services:
   appserver:
     type: ruby:2.5


### PR DESCRIPTION
- addresses error in starting lando, when a key isn't specified