### PR TITLE
PUBD-17 Enable JustifyRight (and other text alignment) in Trumbo

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,10 +55,10 @@ GEM
     mustermann (1.0.2)
     mysql2 (0.4.7)
     netrc (0.11.0)
-    nokogiri (1.11.0)
+    nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogumbo (2.0.2)
+    nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
     parslet (1.8.2)
     power_assert (1.0.2)
@@ -71,7 +71,7 @@ GEM
     rack (2.2.3)
     rack-protection (2.0.2)
       rack
-    sanitize (5.2.1)
+    sanitize (5.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
@@ -139,4 +139,4 @@ RUBY VERSION
    ruby 2.4.7p357
 
 BUNDLED WITH
-   2.0.2
+   2.2.16

--- a/app/jsx/components/WysiwygEditorComp.jsx
+++ b/app/jsx/components/WysiwygEditorComp.jsx
@@ -11,6 +11,7 @@ const TRUMBO_BUTTONS = [
   ['fancyCreateLink', 'unlink'],
   ['image-upload', 'file-upload'],
   ['unorderedList', 'orderedList'],
+  ['align'],
   ['horizontalRule'],
   ['superscript', 'subscript', 'strikethrough'],
   ['fancyRemoveFormat']

--- a/app/jsx/components/WysiwygEditorComp.jsx
+++ b/app/jsx/components/WysiwygEditorComp.jsx
@@ -11,7 +11,7 @@ const TRUMBO_BUTTONS = [
   ['fancyCreateLink', 'unlink'],
   ['image-upload', 'file-upload'],
   ['unorderedList', 'orderedList'],
-  ['align'],
+  ['justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull'],
   ['horizontalRule'],
   ['superscript', 'subscript', 'strikethrough'],
   ['fancyRemoveFormat']

--- a/util/sanitize.rb
+++ b/util/sanitize.rb
@@ -38,8 +38,8 @@ def sanitizeHTML(htmlFragment)
   # Sanitize the result
   return Sanitize.fragment(htmlFragment,
     elements: %w{b em i strong u} +
-              %w{a br li ol p blockquote h1 h2 h3 h4 small strike sub sup ul hr img},
-    attributes: { "a" => ['href'], "img" => ['src', 'alt'] },
+              %w{a br li ol p blockquote h1 h2 h3 h4 small strike sub sup ul hr img style},
+    attributes: { "p" => ['style'], "a" => ['href'], "img" => ['src', 'alt'] },
     protocols:  { "a" => {'href' => ['ftp', 'http', 'https', 'mailto', :relative]},
                   "img" => {'src' => ['http', 'https', :relative]} }
   ).strip

--- a/util/sanitize.rb
+++ b/util/sanitize.rb
@@ -39,8 +39,9 @@ def sanitizeHTML(htmlFragment)
   return Sanitize.fragment(htmlFragment,
     elements: %w{b em i strong u} +
               %w{a br li ol p blockquote h1 h2 h3 h4 small strike sub sup ul hr img style},
-    attributes: { "p" => ['style'], "a" => ['href'], "img" => ['src', 'alt'] },
+    attributes: { "p"  => ['style'], "a" => ['href'], "img" => ['src', 'alt'] },
     protocols:  { "a" => {'href' => ['ftp', 'http', 'https', 'mailto', :relative]},
-                  "img" => {'src' => ['http', 'https', :relative]} }
+                  "img" => {'src' => ['http', 'https', :relative]} },
+    css:        { properties: %w[text-align] }
   ).strip
 end


### PR DESCRIPTION
* Add the default justification buttons to the TRUMBO_BUTTONS constant for TRUMBO
* Allow the style attribute for p tags in sanitizeHTML
* Supercedes #502 
* contains some benign dependency version bumps for these gems: nokogiri, nokogumbo and sanitize