### PR TITLE
Clean up local cache of Ruby gems on lando destroy command

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -61,6 +61,8 @@ services:
       database: local_eschol_prod
 
 events:
+  pre-destroy:
+    - appserver: rm -Rf /app/gems/*
   post-start:
     - appserver: test -e ~/.ssh/config || printf 'Host *\n  AddKeysToAgent yes\n' > ~/.ssh/config
 


### PR DESCRIPTION
- Delete all local gem files in /app/gems whenever the lando destroy
command is run
- will help catch issues where cached gem collections might impact
deployments (see PUBD-124 for an example)