### PR TITLE
PUBD-5 and PUBD-148: only attempt to normalize DOIs that exist

### DIFF
--- a/app/jsx/components/TabSupplementalComp.jsx
+++ b/app/jsx/components/TabSupplementalComp.jsx
@@ -19,7 +19,8 @@ class TabSupplementalComp extends React.Component {
       // mimeSimple = Normalized mimeType value to make filtering files easier
       for (let f of supp_files_orig) {
         // normalize the DOI to recommended best practice
-        if ( ! f.doi.match(/^http/) ) {
+        // -- only attempt this match if we actually have a doi
+        if ( f.doi && ! f.doi.match(/^http/) ) {
             f.doi = 'https://doi.org/' + f.doi
         }
         let mimeSimple = "data"


### PR DESCRIPTION
- Only attempt to normalize a DOI if a DOI exists, otherwise skip it (the regex match doesn't like nulls)