### PR TITLE
Escape search param values as they are parsed out of the query string

### DIFF
--- a/app/server.rb
+++ b/app/server.rb
@@ -1303,11 +1303,15 @@ def getSearchData()
   }
   facetList = ['type_of_work', 'peer_reviewed', 'supp_file_types', 'pub_year',
                'campuses', 'departments', 'journals', 'disciplines', 'rights']
+
   # Does tricky extra stuff with params
-  cgiParams = CGI::parse(request.query_string)
+  cgiParams = CGI::parse(request.query_string).transform_values{|a| a.map{|v| CGI::escapeHTML(v)}}
+  cgiParams.default=[].freeze
+
   forceNumeric(cgiParams, 'start')
   forceNumeric(cgiParams, 'rows')
   searchType = cgiParams["searchType"][0]
+
   # Perform global search when searchType is assigned 'eScholarship'
   # otherwise: 'searchType' will be assigned the unit ID - and then 'searchUnitType' specifies type of unit.
   if searchType and searchType != "eScholarship"

--- a/test/quick.rb
+++ b/test/quick.rb
@@ -117,4 +117,9 @@ class TestQuick < Test::Unit::TestCase
     pdfData = fetch("http://localhost:#{PUMA_PORT}/content/qt5563x8nf/qt5563x8nf.pdf")
     assert_match /Lead Toxicity/, pdfData
   end
+
+  def test_search_escaping
+    html = fetch("http://localhost:#{PUMA_PORT}/search?q=%3C%2Fscript%3E%3CSCRipt%3Ealert(%27NOPE%27)%3C%2Fscript%3E")
+    assert_no_match(/<SCRipt>/, html)
+  end
 end


### PR DESCRIPTION
- Escapes the search terms as they are parsed out of the query string
- Carefully resets the default of the cgiParams hash to [] instead of
nil, to keep the "magic" in-tact