### PR TITLE
PUBD-147 Populate the link rel=canonical on item pages

### DIFF
--- a/app/jsx/pages/ItemPage.jsx
+++ b/app/jsx/pages/ItemPage.jsx
@@ -163,8 +163,8 @@ class ItemPage extends PageBase {
             {!d.download_restricted && d.pdf_url &&
               <meta id="meta-pdf_url" name="citation_pdf_url"
                     content={d.pdf_url.substr(0, 4) == "http" ? d.pdf_url : "https://escholarship.org" + d.pdf_url} /> }
-            {/* rel=canonical below helps hypothes.is properly anchor annotations */}
-            <link rel="canonical" href={!(typeof location === "undefined") ? location.href.replace(/\?.*/,"").replace("/#.*/", "") : ""}/>
+            {/* rel=canonical below helps ensure Google Scholar indexes the correct domain */}
+            <link rel="canonical" href={"https://escholarship.org/uc/item/" + d.id} />
           </MetaTagsComp>
         }
         <Header2Comp type={d.unit ? d.unit.type: null}


### PR DESCRIPTION
- link rel=canonical helps Google Scholar put page info in the correct site index
- link rel=canonical markup was present, but the content wasn't set
correctly
- this PR points Google Scholar at eScholarship.org (woot!)