### PR TITLE
Comment out the Rubocop lint check, it doesn't work for public forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,15 @@
 name: lint-jschol
 on: [push, pull_request]
 jobs: 
-  Rubocop:
-    name: Rubocop
-    runs-on: ubuntu-latest
-    steps:
-     - uses: actions/checkout@v2
-     - uses: gimenete/rubocop-action@1.0
-       env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Rubocop:
+  # disabled 8/3/2021 because this fails for PRs from public forks, and that's not acceptible, we'll live without this lint check
+  #   name: Rubocop
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #    - uses: actions/checkout@v2
+  #    - uses: gimenete/rubocop-action@1.0
+  #      env:
+  #        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ESlint:
     name: ESlint
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since the Rubocop check always fails on pull requests from public forks, and we're planning to replace Github actions with AWS Codebuild for our CI, we should disable the Rubocop lint check for now.