### PR TITLE
Add link rel=canonical to MetaTagsComp invocations on GlobalStaticPage, StatsPage and UnitPage

### DIFF
--- a/app/jsx/pages/GlobalStaticPage.jsx
+++ b/app/jsx/pages/GlobalStaticPage.jsx
@@ -44,7 +44,9 @@ export default class GlobalStaticPage extends PageBase
         <NavBarComp navBar={data.header.nav_bar} unit={data.unit} socialProps={data.header.social} />
         <MetaTagsComp title={data.pageNotFound ? "Not Found" :
                              (data.content && data.content.title) ? data.content.title :
-                             "eScholarship"}/>
+                             "eScholarship"}>
+          <link rel="canonical" href={"https://escholarship.org" + this.props.location.pathname } />
+        </MetaTagsComp>
         { data.pageNotFound
           ? <NotFoundLayout/>
           : <div id="wizardModalBase">

--- a/app/jsx/pages/StatsPage.jsx
+++ b/app/jsx/pages/StatsPage.jsx
@@ -80,6 +80,7 @@ class StatsHeader extends React.Component {
       <div>
         <MetaTagsComp title={`${p.title}: ${p.data.unit_name || p.data.author_name || "current"}`}>
            <meta id="meta-robots" name="robots" content="noindex" />
+           <link rel="canonical" href={"https://escholarship.org" + p.location.pathname } />
         </MetaTagsComp>
         <h1>
           { pageName == "summary" ? thisLabel : <Link to={thisLink}>{thisLabel}</Link> }

--- a/app/jsx/pages/UnitPage.jsx
+++ b/app/jsx/pages/UnitPage.jsx
@@ -129,7 +129,9 @@ class UnitPage extends PageBase {
     }
     return (
       <div>
-        <MetaTagsComp title={title}/>
+        <MetaTagsComp title={title}>
+          <link rel="canonical" href={"https://escholarship.org" + this.props.location.pathname } />
+        </MetaTagsComp>
         { data.unit.type == "root"
           ? <Header1Comp/>
           : <Header2Comp type={data.unit.type} unitID={data.unit.id} />


### PR DESCRIPTION
- Uses location.pathname from props to set the canonical link, and hard codes the domain to escholarship.org with https as the transport