### PR TITLE
PUBD-159-Add Table plugin and button to Trumbowyg toolbar for the CMS

### DIFF
--- a/app/jsx/components/WysiwygEditorComp.jsx
+++ b/app/jsx/components/WysiwygEditorComp.jsx
@@ -13,6 +13,7 @@ const TRUMBO_BUTTONS = [
   ['unorderedList', 'orderedList'],
   ['justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull'],
   ['horizontalRule'],
+  ['table'],
   ['superscript', 'subscript', 'strikethrough'],
   ['fancyRemoveFormat']
 ]

--- a/app/jsx/objects/TrumbowygObj.jsx
+++ b/app/jsx/objects/TrumbowygObj.jsx
@@ -5,6 +5,7 @@ const trumbowygIconsId = 'trumbowyg-icons'
 
 // Load some standard plugins
 import 'trumbowyg/plugins/cleanpaste/trumbowyg.cleanpaste.js'
+import 'trumbowyg/dist/plugins/table/trumbowyg.table.min.js'
 
 // MH CDL: Load our customized plugins
 import './trumbowyg.uploadImage.jsx'

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -9,6 +9,7 @@
 // ***** Added to jschol (not in eschol-ui) ***** //
 @import '../node_modules/flickity/dist/flickity.css';
 @import '../node_modules/trumbowyg/dist/ui/trumbowyg.css';
+@import '../node_modules/trumbowyg/dist/plugins/table/ui/trumbowyg.table.min.css';
 @import '../node_modules/react-sortable-tree/style.css';
 @import 'adminbar';
 @import 'drawer';

--- a/util/sanitize.rb
+++ b/util/sanitize.rb
@@ -38,8 +38,8 @@ def sanitizeHTML(htmlFragment)
   # Sanitize the result
   return Sanitize.fragment(htmlFragment,
     elements: %w{b em i strong u} +
-              %w{a br li ol p blockquote h1 h2 h3 h4 small strike sub sup ul hr img style},
-    attributes: { "p"  => ['style'], "a" => ['href'], "img" => ['src', 'alt'] },
+              %w{a br li ol p blockquote h1 h2 h3 h4 small strike sub sup ul hr img style table tbody tr td},
+    attributes: { "p"  => ['style'], "a" => ['href'], "img" => ['src', 'alt'], "table"  => ['class'], },
     protocols:  { "a" => {'href' => ['ftp', 'http', 'https', 'mailto', :relative]},
                   "img" => {'src' => ['http', 'https', :relative]} },
     css:        { properties: %w[text-align] }


### PR DESCRIPTION
* Add Table plugin and button to the Trumbowyg object. 
* Also add table markup and styles to the sanitize.fragment method, so the table code will survive a save.