### PR TITLE
Run lint checks before the quick test via Lando test tooling

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -97,7 +97,7 @@ tooling:
     description: Runs bundle commands on the Lando Jschol appserver
   test:
     service: appserver
-    cmd: ruby tools/maybeSocks.rb && ruby test/quick.rb
+    cmd: bundle exec rubocop && npx eslint . && ruby tools/maybeSocks.rb && ruby test/quick.rb
     description: Runs the quicktest suite on the Lando Jschol appserver
   socks:
     service: appserver


### PR DESCRIPTION
A minor revision to the test tooling for Lando, to ensure lint checks are run before the code is tested.