### PR TITLE
Integrate UI changes from Joel

### DIFF
--- a/app/jsx/components/AuthorListComp.jsx
+++ b/app/jsx/components/AuthorListComp.jsx
@@ -46,6 +46,7 @@ class AuthorListComp extends React.Component {
             <li><a href="" className="c-authorlist__list-more-link">et al.</a></li>
           </TruncationObj>
         }
+        <div className="c-authorlist__copyright">&copy; 2021 by the author(s). <a href="https://escholarship.org/terms">Learn more</a>.</div>
       </div>
     )
   }

--- a/app/jsx/components/MediaFileGridComp.jsx
+++ b/app/jsx/components/MediaFileGridComp.jsx
@@ -38,9 +38,9 @@ class CellComp extends React.Component {
         
         <button className="o-mediafile__view" onClick={this.handleOpenModal}><span>View Media</span></button>
         <a href={url} className="o-mediafile__download" download={p.file}>Download</a>
-        <a href={p.doi}>{p.doi}</a>
+        <a href={p.doi} className="o-mediafile__doi">{p.doi}</a>
         <MediaModalComp showModal={this.state.showModal} handleCloseModal={this.handleCloseModal}>
-          <MediaFeatureObj file={p.file} url={url} type={mimeSimple} title={p.title} description={p.description} />
+          <MediaFeatureObj file={p.file} url={url} type={mimeSimple} title={p.title} description={p.description} doi={p.doi} />
         </MediaModalComp>
       </div>
     )

--- a/app/jsx/components/PdfViewComp.jsx
+++ b/app/jsx/components/PdfViewComp.jsx
@@ -119,6 +119,9 @@ class PdfViewComp extends React.Component {
           <button onClick={() => {this.view()}} className="c-pdfview__button-download">Download PDF to View</button>
           <button onClick={() => {this.view()}} className="c-pdfview__button-view">View Larger</button>
         </div>
+        <div className="c-pdfview__accessibility">
+          For improved accessibility of PDF content, <a href="">download the file</a> to your device.
+        </div>
         <div className="c-pdfview__viewer">
           <PdfViewerComp url={this.props.url.replace(".pdf", "_noSplash_" + this.props.content_key + ".pdf")
                               + (this.props.preview_key ? separator+"preview_key=" + this.props.preview_key : "")}/>

--- a/app/jsx/layouts/AuthorSearchLayout.jsx
+++ b/app/jsx/layouts/AuthorSearchLayout.jsx
@@ -18,7 +18,7 @@ export default class AuthorSearchLayout extends React.Component
     let p = this.props
     return (
       <div className="c-columns">
-        <main id="maincontent" tabIndex="-1">
+        <main id="maincontent">
           <section className="o-columnbox1">
             <header>
               <h1 className="o-columnbox1__heading">

--- a/app/jsx/layouts/CampusLayout.jsx
+++ b/app/jsx/layouts/CampusLayout.jsx
@@ -76,7 +76,7 @@ class CampusLayout extends React.Component {
         <CampusHeroComp hero={data.hero} campusID={unit.id} />
         <StatCarouselComp campusName={unit.name} campusID={unit.id} campusStats={data.campusStats} allStats={data.allStats} />
         <div className="c-columns">
-          <main id="maincontent" tabIndex="-1">
+          <main id="maincontent">
             <CampusSearchComp campusID={unit.id} campusName={unit.name} />
          {data.contentCar1 && data.contentCar1.mode && data.contentCar1.mode != 'disabled' && data.contentCar1.data &&
             this.renderCampusCarousel(data.contentCar1)

--- a/app/jsx/layouts/DepartmentLayout.jsx
+++ b/app/jsx/layouts/DepartmentLayout.jsx
@@ -86,7 +86,7 @@ class DepartmentLayout extends React.Component {
         <MarqueeComp marquee={marquee} />
       }
         <div className="c-columns">
-          <main id="maincontent" tabIndex="-1">
+          <main id="maincontent">
             <section className="o-columnbox1">
               <header>
                 <h2>{this.props.unit.name}</h2>

--- a/app/jsx/layouts/Error404Layout.jsx
+++ b/app/jsx/layouts/Error404Layout.jsx
@@ -64,7 +64,7 @@ class Error404Layout extends React.Component {
           </div>
         </div>
         <div className="c-columns">
-          <main id="maincontent" tabIndex="-1">
+          <main id="maincontent">
             <section className="o-columnbox1">
               <ServerErrorComp />
             </section>

--- a/app/jsx/layouts/JournalLayout.jsx
+++ b/app/jsx/layouts/JournalLayout.jsx
@@ -140,7 +140,7 @@ class JournalLayout extends React.Component {
         <MarqueeComp marquee={marquee} />
       }
         <div className="c-columns">
-          <main id="maincontent" tabIndex="-1">
+          <main id="maincontent">
           {this.props.data.issue ?
             <IssueWrapperComp issue={data.issue} issues={data.issuesSubNav} display={data.display} />
           :

--- a/app/jsx/layouts/RedirectConfigLayout.jsx
+++ b/app/jsx/layouts/RedirectConfigLayout.jsx
@@ -57,7 +57,7 @@ export default class RedirectConfigLayout extends React.Component
     let p = this.props
     return (
       <div className="c-columns">
-        <main id="maincontent" tabIndex="-1">
+        <main id="maincontent">
           <section className="o-columnbox1">
             <header>
               <h1 className="o-columnbox1__heading">

--- a/app/jsx/layouts/SeriesLayout.jsx
+++ b/app/jsx/layouts/SeriesLayout.jsx
@@ -102,7 +102,7 @@ class SeriesLayout extends React.Component {
     return (
       <div className="c-columns">
         {/* No marquee component used in series layout. But note marquee.about data used below */}
-        <main id="maincontent" tabIndex="-1">
+        <main id="maincontent">
           <section className="o-columnbox1">
             <div className="c-itemactions">
             {data.series.length > 1 ?

--- a/app/jsx/layouts/UnitBuilderLayout.jsx
+++ b/app/jsx/layouts/UnitBuilderLayout.jsx
@@ -71,7 +71,7 @@ export default class UnitBuilderLayout extends React.Component
     let p = this.props
     return (
       <div className="c-columns">
-        <main id="maincontent" tabIndex="-1">
+        <main id="maincontent">
           <section className="o-columnbox1">
             <header>
               <h1 className="o-columnbox1__heading">

--- a/app/jsx/layouts/UnitNavConfigLayout.jsx
+++ b/app/jsx/layouts/UnitNavConfigLayout.jsx
@@ -123,7 +123,7 @@ export default class UnitNavConfigLayout extends React.Component
     let p = this.props
     return (
       <div className="c-columns">
-        <main id="maincontent" tabIndex="-1">
+        <main id="maincontent">
           <section className="o-columnbox1">
             <header>
               <h1 className="o-columnbox1__heading">

--- a/app/jsx/layouts/UnitSearchLayout.jsx
+++ b/app/jsx/layouts/UnitSearchLayout.jsx
@@ -48,7 +48,7 @@ class UnitSearchLayout extends React.Component {
     var data = this.props.data;
     return (
       <div className="c-columns">
-        <main id="maincontent" tabIndex="-1">
+        <main id="maincontent">
           <section className="o-columnbox1">
             <SortPaginationComp query={data.query} count={data.count}/>
             <div>

--- a/app/jsx/layouts/UnitSidebarConfigLayout.jsx
+++ b/app/jsx/layouts/UnitSidebarConfigLayout.jsx
@@ -89,7 +89,7 @@ export default class UnitSidebarConfigLayout extends React.Component
     let kindStr = p.data.kind == "Text" ? "text widget" : "built-in widget"
     return (
       <div className="c-columns">
-        <main id="maincontent" tabIndex="-1">
+        <main id="maincontent">
           <section className="o-columnbox1">
             <header>
               <h1 className="o-columnbox1__heading">

--- a/app/jsx/layouts/UnitStaticPageLayout.jsx
+++ b/app/jsx/layouts/UnitStaticPageLayout.jsx
@@ -20,7 +20,7 @@ class UnitStaticPageLayout extends React.Component
   render() {
     return (
       <div className="c-columns">
-        <main id="maincontent" tabIndex="-1">
+        <main id="maincontent">
           <section className="o-columnbox1">
             <header>
               <h1 className="o-columnbox1__heading">{this.props.data.title}</h1>

--- a/app/jsx/objects/MediaFeatureObj.jsx
+++ b/app/jsx/objects/MediaFeatureObj.jsx
@@ -32,6 +32,7 @@ class MediaFeatureObj extends React.Component {
           }
       })()}
         <div className="o-mediafeature__description">{this.props.description}</div>
+        <a href="{this.props.doi}" className="o-mediafeature__doi">{this.props.doi}</a>
       </div>
     )
   }

--- a/app/scss/_authorlist.scss
+++ b/app/scss/_authorlist.scss
@@ -1,35 +1,19 @@
 // ##### Author List Component ##### //
 
 .c-authorlist {
+  display: grid;
+  grid-template-columns: auto 1fr;
   margin-bottom: $spacing-md;
-
-  @include bp(screen1) {
-    display: flex;
-  }
-
 }
 
 .c-authorlist__year {
   align-self: flex-start;
-  margin-right: $spacing-sm;
-  padding-right: $spacing-sm;
-  border-right: 1px solid $color-black;
-}
 
-%c-authorlist__item {
-    display: inline-block;
-
-    &:nth-last-child(n+4) {
-
-      &::after {
-        content: '\00a0'; // no-break space
-      }
-
-    }
-
-    a {
-      @extend %o-textlink__secondary;
-    }
+  + .c-authorlist__list {
+    margin-left: $spacing-sm;
+    padding-left: $spacing-sm;
+    border-left: 1px solid $color-black;
+  }
 }
 
 .c-authorlist__list {
@@ -38,22 +22,12 @@
   overflow: hidden; // hide text beyond max-height
 
   li {
-    @extend %c-authorlist__item;
-  }
+    display: inline-block;
 
-  li:not(.c-authorlist__end) {
-    @extend %c-authorlist__item;
-
-    &:nth-last-child(n+3) {
-
-      &::after {
-      content: ';\00a0'; // semicolon with no-break space
-      }
-
+    a {
+      @extend %o-textlink__secondary;
     }
-
   }
-
 }
 
 .c-authorlist__heading {
@@ -61,8 +35,8 @@
   font-weight: bold; 
 }
 
-.c-authorlist__list .c-authorlist__begin:nth-of-type(n+2)::before {
-  content: '\00a0';
+.c-authorlist__end {
+  margin-right: 0.3rem;
 }
 
 .c-authorlist__list-more-link {
@@ -73,4 +47,12 @@
     content: ';\00a0';
   }
 
+}
+
+.c-authorlist__copyright {
+  grid-column: 1 / 3;
+
+  a {
+    @extend %o-textlink__secondary;
+  }
 }

--- a/app/scss/_mediafeature.scss
+++ b/app/scss/_mediafeature.scss
@@ -22,7 +22,13 @@
 }
 
 .o-mediafeature__description {
+  margin-bottom: $spacing-sm;
   order: 3;
+}
+
+.o-mediafeature__doi {
+  @extend %o-textlink__secondary;
+  order: 4;
 }
 
 .o-mediafeature--audio {

--- a/app/scss/_mediafile.scss
+++ b/app/scss/_mediafile.scss
@@ -12,7 +12,7 @@ div[class^='o-mediafile--'] {
   @include bp(screen1) {
     padding: $spacing-sm;
     grid-template-columns: 1fr 1fr;
-    grid-template-rows: auto 1fr auto;
+    grid-template-rows: auto auto auto 1fr;
     grid-column-gap: $spacing-sm;
 
     &:not(:last-child) {
@@ -30,7 +30,7 @@ div[class^='o-mediafile--'] {
   background: no-repeat top left / 0.9em;
   font-size: 1.1em;
   font-weight: normal;
-  grid-column: 1;
+  grid-column: 1 / 3;
   grid-row: 1;
 
   @include bp(screen1) {
@@ -47,10 +47,11 @@ div[class^='o-mediafile--'] {
 
 .o-mediafile__preview {
   position: relative;
-  height: 7.5em;
+  height: 8.5em;
   margin-bottom: $spacing-sm;
   background-color: $color-dark-gray;
   cursor: pointer;
+  grid-column: 1 / 3;
 
   &::before {
     position: absolute;
@@ -64,7 +65,8 @@ div[class^='o-mediafile--'] {
   }
 
   @include bp(screen1) {
-    grid-row: 1 / 4;
+    grid-column: 1;
+    grid-row: 1 / 5;
 
     @supports (display: grid) {
       margin-bottom: 0;
@@ -84,6 +86,7 @@ div[class^='o-mediafile--'] {
 .o-mediafile__description {
   margin-bottom: $spacing-sm;
   font-size: 0.9em;
+  grid-column: 1 / 3;
 
   @include bp(screen1) {
     max-height: 3.2em; // truncate beyond 3 lines per jquery.dotdotdot
@@ -119,12 +122,29 @@ div[class^='o-mediafile--'] {
 
 }
 
-.o-mediafile__download {
+.o-mediafile__doi {
   @extend %o-textlink__secondary;
-  float: right;
-  justify-self: end;
+  margin-bottom: $spacing-sm;
+  grid-column: 1 / 3;
+  grid-row: 3;
 
   @include bp(screen1) {
+    grid-column: 2;
+    max-height: 1.3em; // truncate beyond 2 lines per jquery.dotdotdot
+    overflow: hidden; // hide text beyond max-height
+  }
+}
+
+.o-mediafile__download {
+  @extend %o-textlink__secondary;
+  margin-bottom: $spacing-sm;
+  justify-self: end;
+  grid-column: 2;
+  grid-row: 4;
+  align-self: end;
+
+  @include bp(screen1) {
+    margin-bottom: 0;
     justify-self: start;
   }
 

--- a/app/scss/_pdfview.scss
+++ b/app/scss/_pdfview.scss
@@ -37,12 +37,25 @@
 
 }
 
+.c-pdfview__accessibility {
+  display: none;
+
+  a {
+    @extend %o-textlink__secondary;
+  }
+
+  @include bp(screen1) {
+    display: block;
+    margin-top: $spacing-sm;
+    margin-bottom: $spacing-sm;
+  }
+}
+
 .c-pdfview__viewer {
   display: none;
 
   @include bp(screen1) {
     display: block;
-    margin-top: $spacing-sm;
   }
 
 }

--- a/app/scss/_resets.scss
+++ b/app/scss/_resets.scss
@@ -8,12 +8,6 @@
   box-sizing: border-box;
 }
 
-// Set common style to all focusable elements:
-
-*:focus {
-  outline: $color-dark-orange solid 1px;
-}
-
 abbr {
   border: none; // for older browsers
   text-decoration: none; // for newer browsers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1900,9 +1900,9 @@
       "dev": true
     },
     "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
       "dev": true,
       "requires": {
         "delegates": "^1.0.0",
@@ -1916,9 +1916,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -7865,9 +7865,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -8302,9 +8302,9 @@
       }
     },
     "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.3.tgz",
+      "integrity": "sha512-mb1aYtDbIjTu4ShMB85m3UzjX9BVKe9WCzsnfMSZk+K5GpIbBOexgg4PPCt5eHDEG5/ZQAUX2Kct02zfiPLsKg==",
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
@@ -9034,13 +9034,13 @@
       }
     },
     "gulp-sass": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-4.0.2.tgz",
-      "integrity": "sha512-q8psj4+aDrblJMMtRxihNBdovfzGrXJp1l4JU0Sz4b/Mhsi2DPrKFYCGDwjIWRENs04ELVHxdOJQ7Vs98OFohg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-4.1.1.tgz",
+      "integrity": "sha512-bg7mfgsgho0Ej0WXE9Cd2sq/YxeKxOjagrMmM40zvOYXHtZvi5ED84wIpqCUvJLz66kFNkv+jS/rQXolmgXrUQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
-        "lodash.clonedeep": "^4.3.2",
+        "lodash": "^4.17.20",
         "node-sass": "^4.8.3",
         "plugin-error": "^1.0.1",
         "replace-ext": "^1.0.0",
@@ -9081,6 +9081,12 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
         "plugin-error": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
@@ -9094,9 +9100,9 @@
           }
         },
         "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+          "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
           "dev": true
         },
         "strip-ansi": {
@@ -10086,9 +10092,9 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "in-publish": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
       "dev": true
     },
     "indent-string": {
@@ -12269,9 +12275,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
       "dev": true
     },
     "nanomatch": {
@@ -12494,9 +12500,9 @@
       }
     },
     "node-sass": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
-      "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
+      "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -12506,14 +12512,14 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
         "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
         "request": "^2.88.0",
-        "sass-graph": "^2.2.4",
+        "sass-graph": "2.2.5",
         "stdout-stream": "^1.4.0",
         "true-case-path": "^1.0.2"
       },
@@ -12527,6 +12533,12 @@
             "lru-cache": "^4.0.1",
             "which": "^1.2.9"
           }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
         }
       }
     },
@@ -15168,42 +15180,185 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass-graph": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
+      "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
         "lodash": "^4.0.0",
         "scss-tokenizer": "^0.2.3",
-        "yargs": "^7.0.0"
+        "yargs": "^13.3.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
         "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true
         },
         "yargs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
+            "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -15837,9 +15992,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -16451,13 +16606,13 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gulp-livereload": "^4.0.1",
     "gulp-modernizr": "^3.2.1",
     "gulp-postcss": "^6.4.0",
-    "gulp-sass": "^4.0.2",
+    "gulp-sass": "^4.1.1",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-streamify": "^1.0.2",
     "gulp-uglify": "^1.5.4",


### PR DESCRIPTION
Integrates changes from eschol-ui made since July 5, 2021, including:

- removing tabIndex from all layouts
- bumping the version of node-sass to 4.14.1 (via a bump to gulp-sass to 4.1.1)
- porting changes to AuthorListComp, PdfViewComp, MediaFileGripComp and MediaFeatureObj