### PR TITLE
Fixes PUBD-299, a pagination error in Jschol

### DIFF
--- a/app/jsx/components/FilterComp.jsx
+++ b/app/jsx/components/FilterComp.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import _ from 'lodash'
-
+import unescape from 'lodash/unescape'
 class FilterComp extends React.Component {
   state = { isOpen: true }  // open only becomes false when user clicks it to hide (handled by CSS)
 
@@ -43,7 +43,7 @@ class FilterComp extends React.Component {
       <div className={activeFilters ? "c-filter--active" : "c-filter"}>
         {/* we trust searchString (We have escaped the params already), this is fine */}
         <h1 className="c-filter__heading" dangerouslySetInnerHTML={{__html: searchString}} />
-        <input type="hidden" name="q" value={this.props.query.q == "All items" ? "" : this.props.query.q} />
+        <input type="hidden" name="q" value={this.props.query.q == "All items" ? "" : unescape(this.props.query.q)} />
         <div className="c-filter__results">{resultCount} results</div>
         <div className="c-filter__inactive-note">No filters applied</div>
         <details className="c-filter__active" open={this.state.isOpen}>

--- a/test/quick.rb
+++ b/test/quick.rb
@@ -132,4 +132,10 @@ class TestQuick < Test::Unit::TestCase
     html = fetch("http://localhost:#{PUMA_PORT}/search?q=author%3A%22Adelman%2C%20Irma%22")
     assert_match(/Food Security/, html)
   end
+
+  def test_author_search_pagination
+    html = fetch("http://localhost:#{PUMA_PORT}/search?q=author%3A%22Brozen%2C%20Madeline%22")
+    assert_match(/input type=\"hidden\" name=\"q\" value=\"author:&quot;Brozen, Madeline&quot;\"/, html)
+  end
+
 end


### PR DESCRIPTION
* Ensures the hidden form field in FilterComp that holds the search query is properly unescaped (and usable)
* Adds a test that confirms that an author search results in a properly escaped hidden form field in FilterComp