### PR TITLE
PUBD-336: actually link to the PDF, and add popup for restricted items

### DIFF
--- a/app/jsx/components/PdfViewComp.jsx
+++ b/app/jsx/components/PdfViewComp.jsx
@@ -109,7 +109,7 @@ class PdfViewComp extends React.Component {
 
   render() {
     let separator = this.props.url.indexOf("?") >= 0 ? "&" : "?"
-    let pdf_url = this.props.url.replace(".pdf", "_noSplash_" + this.props.content_key + ".pdf") + (this.props.preview_key ? separator+"preview_key=" + this.props.preview_key : "")
+    let pdf_url = this.props.url + (this.props.preview_key ? separator+"preview_key=" + this.props.preview_key : "")
     return (
       <details className="c-togglecontent" open>
         {/* ScrollingAnchor sits here and not above because c-togglecontent styling relies on

--- a/app/jsx/components/PdfViewComp.jsx
+++ b/app/jsx/components/PdfViewComp.jsx
@@ -109,6 +109,7 @@ class PdfViewComp extends React.Component {
 
   render() {
     let separator = this.props.url.indexOf("?") >= 0 ? "&" : "?"
+    let pdf_url = this.props.url.replace(".pdf", "_noSplash_" + this.props.content_key + ".pdf") + (this.props.preview_key ? separator+"preview_key=" + this.props.preview_key : "")
     return (
       <details className="c-togglecontent" open>
         {/* ScrollingAnchor sits here and not above because c-togglecontent styling relies on
@@ -120,7 +121,9 @@ class PdfViewComp extends React.Component {
           <button onClick={() => {this.view()}} className="c-pdfview__button-view">View Larger</button>
         </div>
         <div className="c-pdfview__accessibility">
-          For improved accessibility of PDF content, <a href="">download the file</a> to your device.
+          For improved accessibility of PDF content, {this.props.download_restricted 
+          ? <a href={pdf_url} onClick={()=>{alert("Download restricted until " + this.props.download_restricted); return false}}>Download PDF</a>
+          : <a href={pdf_url} >download the file</a> } to your device.  
         </div>
         <div className="c-pdfview__viewer">
           <PdfViewerComp url={this.props.url.replace(".pdf", "_noSplash_" + this.props.content_key + ".pdf")


### PR DESCRIPTION
Change the link to the PDF, and use the same popup logic for restricted items as is present for the download button.