### PR TITLE
PUBD-416: Tame MathJax rendering issues

### DIFF
--- a/app/js/mathjax-typeset.js
+++ b/app/js/mathjax-typeset.js
@@ -1,0 +1,1 @@
+MathJax.typeset();

--- a/app/js/mathjax-typeset.js
+++ b/app/js/mathjax-typeset.js
@@ -1,1 +1,2 @@
+/* eslint-disable no-undef */
 MathJax.typeset();

--- a/app/jsx/components/Header2Comp.jsx
+++ b/app/jsx/components/Header2Comp.jsx
@@ -67,6 +67,12 @@ class HeaderComp2 extends React.Component {
       </div>
     )
   }
+  componentDidMount() {
+    // I can haz MathJax?
+    {this.props.unitID=="combinatorial_theory" &&
+    <script id="MathJaxTypeset" src="/js/mathjax-typeset.js"/>
+    }
+  }
 }
 
 export default HeaderComp2;

--- a/app/jsx/components/Header2Comp.jsx
+++ b/app/jsx/components/Header2Comp.jsx
@@ -68,7 +68,7 @@ class HeaderComp2 extends React.Component {
     )
   }
   componentDidMount() {
-    // I can haz MathJax?
+    // Typeset MathJax
     {this.props.unitID=="combinatorial_theory" &&
     <script id="MathJaxTypeset" src="/js/mathjax-typeset.js"/>
     }


### PR DESCRIPTION
- Add call to MathJax.typeset() in a componentDidMount, which should force
the rendering of MathJax, if there's any to render