### PR TITLE
Refactor out unneccessary and potentially slow regex matches

### DIFF
--- a/app/jsx/components/TabSupplementalComp.jsx
+++ b/app/jsx/components/TabSupplementalComp.jsx
@@ -20,7 +20,7 @@ class TabSupplementalComp extends React.Component {
       for (let f of supp_files_orig) {
         // normalize the DOI to recommended best practice
         // -- only attempt this match if we actually have a doi
-        if ( f.doi && ! f.doi.match(/^http/) ) {
+        if ( f.doi && ! f.doi.startsWith('http') ) {
             f.doi = 'https://doi.org/' + f.doi
         }
         let mimeSimple = "data"

--- a/app/jsx/utils.jsx
+++ b/app/jsx/utils.jsx
@@ -21,7 +21,7 @@ export default class {
    * Wraps HTML with p tag if not present
    */
   static p_wrap(html) {
-    if (html.match(/^<p>.*<\/p>$/)) return html
+    if (html.startsWith('<p>') && html.endsWith('</p>')) return html
     return '<p>'+ html +'</p>'
   }
 }


### PR DESCRIPTION
- Replace two unneccessary regex matches with startsWith and endsWith