### PR TITLE
Add more beanstalk capabilities e.g. deploy, promote, watch

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -50,6 +50,9 @@ services:
     run_as_root:
       - chown www-data:www-data /run/host-services/ssh-auth.sock
       - chmod g+w /run/host-services/ssh-auth.sock
+      - ln -s /user/.aws /var/www/.aws
+      - apt-get install -y less zip jq groff
+      - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip  -nqq awscliv2.zip && ./aws/install
 
     moreHttpPorts:
       - '18880'
@@ -85,6 +88,36 @@ tooling:
     description: Runs the quicktest suite on the Lando Jschol appserver
     env:
       SCHEME: http
+  irb:
+    service: appserver
+    cmd: GEM_PATH=/app/gems/gems irb
+    dir: /app
+    description: Runs irb on the Jschol appserver (for some good REPL fun)
+  deploy:
+    service: appserver
+    cmd: /app/deployVersion.sh
+    description: Runs the deployment script to deploy to Elastic Beanstalk
+  promote:
+    service: appserver
+    cmd: /app/promoteVersion.sh
+    description: Promote an Elastic Beanstalk app from one environment to another
+  aws:
+    service: appserver
+    cmd: aws --profile pub
+    dir: /app
+    description: Runs AWS-cli commands on the Jschol appserver
+  watch-stg:
+    service: appserver
+    cmd: watch -d aws --profile pub elasticbeanstalk describe-environments --environment-name eb-pub-jschol2-stg
+    description: Watches eb-pub-jschol2-stg aws environment details for updates.
+  watch-dev:
+    service: appserver
+    cmd: watch -d aws --profile pub elasticbeanstalk describe-environments --environment-name eb-pub-jschol2-dev
+    description: Watches eb-pub-jschol2-dev aws environment details for updates.
+  watch-prd:
+    service: appserver
+    cmd: watch -d aws --profile pub elasticbeanstalk describe-environments --environment-name eb-pub-jschol2-prd
+    description: Watches eb-pub-jschol2-prd aws environment details for updates.
   test:
     service: appserver
     cmd: bundle exec rubocop && npx eslint . && ruby tools/maybeSocks.rb && ruby test/quick.rb

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This app uses the following technology and features:
 * Automatic rebuilds using Gulp
 * LiveReload support so changes during development are reflected instantly in the browser
 * Isometric Javascript to provide server-side initial rendering of pages (for fast first load, and for better crawlability)
-* [Lando](https://lando.dev/) for bootstrapping a Docker-based development environment
+* [Lando](https://lando.dev/) for bootstrapping a Docker-based development
+  environment
+* [AWS CLI](https://aws.amazon.com/cli/) for deploying to Elastic Beanstalk. See our [AWS CLI Cheatsheet](https://github.com/cdlib/pad-sys-doc/blob/main/cheatsheet/aws-cli.md).
 
 Description of files
 --------------------
@@ -44,7 +46,14 @@ Description of files
 * `tools/`: Conversion and database maintenance tools.
 * `defaults.env`: default environment variable configuration for Lando
 * `local.env.example`: example file for customizing your Lando dev workspace's environment variables, copy to `local.env` and customize as appropriate
-* `.lando.local.yml.example`: example file for customizing your Lando dev workspace's Lando configuration, copy to `.lando.local.yml` and customize as appropriate
+* `.lando.local.yml.example`: example file for customizing your Lando dev
+  workspace's Lando configuration, copy to `.lando.local.yml` and customize as
+  appropriate
+* `deployVersion.sh`: deployment script, requires an active AWS CLI credential.
+  See our [AWS CLI Cheatsheet](https://github.com/cdlib/pad-sys-doc/blob/main/cheatsheet/aws-cli.md).
+* `promoteVersion.sh` script to promote a tested version of this app from one
+  beanstalk environment to another. Requires an active AWS CLI credential. See
+  our [AWS CLI Cheatsheet](https://github.com/cdlib/pad-sys-doc/blob/main/cheatsheet/aws-cli.md).
 
 Steps to get the app running on your local machine, with Lando
 1. Make sure [Lando](https://lando.dev/) is installed
@@ -68,8 +77,12 @@ Run `lando` to see what other lando commands are available.
 
 Tooling
 -------
+* `lando aws` Runs AWS-cli commands on the Jschol appserver
 * `lando bundle` Runs bundle commands on the Lando Jschol appserver
+* `lando deploy` Runs the deployment script to deploy to Elastic Beanstalk
+* `lando irb` Runs irb on the Jschol appserver (for some good REPL fun)
 * `lando npm` Runs npm commands on the Lando Jschol appserver
+* `lando promote` Promote an Elastic Beanstalk app from one environment to another
 * `lando ruby`  Runs ruby commands on the Lando Jschol appserver
 * `lando socks` Sets the socks proxy tunnel back up, if you have been too idle
 * `lando ssh` Drops into a shell on a service, runs commands

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Description of files
 * `promoteVersion.sh` script to promote a tested version of this app from one
   beanstalk environment to another. Requires an active AWS CLI credential. See
   our [AWS CLI Cheatsheet](https://github.com/cdlib/pad-sys-doc/blob/main/cheatsheet/aws-cli.md).
+* `overlay_files` folder for beanstalk app overlays, used by the deployVersion.sh script. You'll want to grab the contents of this folder from the `pub-cattle2-ops` ec2 instance, if you want to deploy from your Lando dev environment.
 
 Steps to get the app running on your local machine, with Lando
 1. Make sure [Lando](https://lando.dev/) is installed
@@ -88,6 +89,9 @@ Tooling
 * `lando ssh` Drops into a shell on a service, runs commands
 * `lando start` Starts the Jschol app
 * `lando stop` Stops the Jschol app
+* `lando watch-dev` Watches eb-pub-jschol2-dev aws environment details for updates.
+* `lando watch-prd` Watches eb-pub-jschol2-prd aws environment details for updates.
+* 'lando watch-stg` Watches eb-pub-jschol2-stg aws environment details for updates.
 
 More [tooling](https://docs.lando.dev/config/tooling.html) can be added easily.
 

--- a/defaults.env
+++ b/defaults.env
@@ -11,6 +11,11 @@
 # local.env and then set the values in local.env appropriately.
 #
 ###############################################################################
+# AWS CLI OPTIONS
+AWS_DEFAULT_REGION=us-west-2
+LESS='FXmR'
+
+###############################################################################
 THUMBNAIL_SERVER=https://pub-submit2-dev.escholarship.org
 PEOPLE_ARK_SHOULDER=ark:/99999/fk4
 
@@ -38,7 +43,7 @@ PUMA_PORT=18880
 PUMA_WORKERS=1
 PUMA_THREADS=4
 ISO_PORT=4002
-ISO_WORKERS=1
+ISO_WORKERS=0
 
 ###############################################################################
 ESCHOL_API_SERVER=https://pub-jschol2-stg.escholarship.org

--- a/defaults.env
+++ b/defaults.env
@@ -43,7 +43,6 @@ PUMA_PORT=18880
 PUMA_WORKERS=1
 PUMA_THREADS=4
 ISO_PORT=4002
-ISO_WORKERS=1
 
 ###############################################################################
 ESCHOL_API_SERVER=https://pub-jschol2-stg.escholarship.org

--- a/defaults.env
+++ b/defaults.env
@@ -43,7 +43,7 @@ PUMA_PORT=18880
 PUMA_WORKERS=1
 PUMA_THREADS=4
 ISO_PORT=4002
-ISO_WORKERS=0
+ISO_WORKERS=1
 
 ###############################################################################
 ESCHOL_API_SERVER=https://pub-jschol2-stg.escholarship.org

--- a/deployVersion.sh
+++ b/deployVersion.sh
@@ -37,8 +37,18 @@ APPNAME=eb-pub-jschol2
 # make sure we don't push non-prd branch to prd
 CUR_BRANCH=`git rev-parse --abbrev-ref HEAD`
 if [[ "$1" == *"prd"* && "$CUR_BRANCH" != "prd" ]]; then
-  echo "Sanity check: should only push prd branch to prd environment."
+  echo "Sanity check: should only push prd branch to prd environment.\n\nAND you should be using promote-version.sh to promote a tested version to prd.\n\nAborting..."
   exit 1
+fi
+
+# if we're trying to deploy to prd, nag and confirm
+if [[ "$1" == *"prd"* ]]; then
+  echo "Sanity check: you should really only promote to prd using the promote-version.sh script.\n\n"
+  read -p "If you know what you're doing, you may continue by re-entering the target environment-name now: " target
+  case "$target" in
+      $1 ) echo "\nOK, we will proceed...";;;
+      * ) echo "\nIncorrect, aborting..." && exit 1;;;
+  esac
 fi
 
 # make sure environment actually exists

--- a/promoteVersion.sh
+++ b/promoteVersion.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+DEBUG=
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+set -o pipefail  # trace ERR through pipes
+set -o errtrace  # trace ERR through 'time command' and other functions
+set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable
+set -o errexit   ## set -e : exit the script if any statement returns a non-true return value
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # http://stackoverflow.com/questions/59895
+cd $DIR
+
+usage(){
+    echo "promote-version.sh source-environment-name target-environment-name"
+    exit 1
+}
+
+if [ $# -ne 2 ];
+  then
+    usage
+fi
+
+set -u
+
+export TZ=":America/Los_Angeles"
+
+echo "Getting VersionLabel from source environment..."
+VERSION=$(aws elasticbeanstalk describe-environments \
+    --environment-name $1 \
+    | jq '.Environments[0].VersionLabel' | tr -d '"')
+
+echo "version: ${VERSION}"
+
+REGION=us-west-2
+APPNAME=eb-pub-jschol2
+
+
+# make sure target environment actually exists
+echo "Checking target environment."
+env_exists=$(aws elasticbeanstalk describe-environments \
+  --environment-name "$2" \
+  --no-include-deleted \
+  --region $REGION \
+  | egrep -c 'Status.*Ready')
+
+if [[ env_exists -ne 1 ]]
+  then
+    echo "environment $2 does not exist"
+    usage
+fi
+
+echo "Promoting from source environment to target environment..."
+echo "  source: ${1}"
+echo "  target: ${2}"
+# deploy app to a running environment
+aws elasticbeanstalk update-environment \
+  --environment-name "$2" \
+  --region $REGION \
+  --version-label "$VERSION"
+
+# Wait for the deploy to complete.
+echo "Waiting for deploy to finish."
+PREV_DATETIME=""
+while [[ 1 ]]; do
+  STATUS_JSON=`aws elasticbeanstalk describe-events --environment-name "$2" --region $REGION --max-items 1`
+  DATETIME=`echo "$STATUS_JSON" | jq '.Events[0].EventDate' | sed 's/"//g'`
+  MSG=`echo "$STATUS_JSON" | jq '.Events[0].Message' | sed 's/"//g'`
+  if [[ "$PREV_DATETIME" != "$DATETIME" ]]; then
+    PREV_DATETIME="$DATETIME"
+    echo "$DATETIME: $MSG"
+    if [[ "$MSG" =~ "update completed" ]]; then break; fi
+  fi
+  sleep 5
+done
+
+# Invalidate the CloudFront cache
+echo "Invalidating CloudFront cache."
+if [[ "$2" =~ "-stg" ]]; then
+  aws cloudfront create-invalidation --distribution-id E1PJWI7L2EBN0N --paths '/*'
+elif [[ "$2" =~ "-prd" ]]; then
+  aws cloudfront create-invalidation --distribution-id E1KER2WHN1RBOD --paths '/*'
+fi
+
+echo "Promotion complete."
+
+exit 0
+
+# Copyright (c) 2022, Regents of the University of California
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# - Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# - Neither the name of the University of California nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.

--- a/promoteVersion.sh
+++ b/promoteVersion.sh
@@ -48,13 +48,23 @@ env_exists=$(aws elasticbeanstalk describe-environments \
 
 if [[ env_exists -ne 1 ]]
   then
-    echo "environment $2 does not exist"
+    echo "target environment $2 does not exist"
     usage
 fi
 
 echo "Promoting from source environment to target environment..."
+echo "  version label: ${VERSION}"
 echo "  source: ${1}"
 echo "  target: ${2}"
+
+# pause to confirm
+echo "Please confirm you wish to promote the above version to the target environment.\n\n"
+read -p "You may continue by re-entering the target environment-name now: " target
+case "$target" in
+    $1 ) echo "\nOK, we will proceed...";;;
+    * ) echo "\nIncorrect, aborting..." && exit 1;;;
+esac
+
 # deploy app to a running environment
 aws elasticbeanstalk update-environment \
   --environment-name "$2" \


### PR DESCRIPTION
Adds some more beanstalk capabilities, including 

* the ability to run deployVersion.sh from a Lando dev environment
* a new promoteVersion.sh script that promotes the application version in a given source environment to a given target environment
* new tooling for the above
* new tooling for watching dev,stg, and prd beanstalks (easier to run than the dashboard, and faster, too)