### PR TITLE
put publishing dates into the database

### DIFF
--- a/tools/convert.rb
+++ b/tools/convert.rb
@@ -991,6 +991,9 @@ def parseUCIngest(itemID, inMeta, fileType, isPending)
   attrs[:pub_web_loc] = inMeta.xpath("./context/publishedWebLocation").map { |el| el.text.strip }
   attrs[:publisher] = inMeta.text_at("./publisher")
   attrs[:suppress_content] = shouldSuppressContent(itemID, inMeta)
+  attrs[:pub_submit] = parseDate(inMeta[:dateSubmitted])
+  attrs[:pub_accept] = parseDate(inMeta[:dateAccepted])
+  attrs[:pub_publish] = parseDate(inMeta[:datePublish])
 
   # Record submitter (especially useful for forensics)
   attrs[:submitter] = inMeta.xpath("./history/stateChange").map { |sc|


### PR DESCRIPTION
This script is called by subiGuts to added data parsed from API submissions to the db.  I added the OASPA tracking dates to the uci schema and subiGuts processing.