### PR TITLE
Render all math content on page load, simplify configuration

### DIFF
--- a/app/jsx/components/ArbitraryHTMLComp.jsx
+++ b/app/jsx/components/ArbitraryHTMLComp.jsx
@@ -39,7 +39,7 @@ export default class ArbitraryHTMLComp extends React.Component
       let fixedText2 = fixedText.replace(/<a href=\"http:\/\/open-deposit-wizard\.com\">/g,
         '<a href="" onClick="openDepositWiz(event);">')
       this.props.p_wrap && (fixedText2 = Utils.p_wrap(fixedText2))
-      if (!(typeof document === "undefined") && /\$[^0-9/\.]/.test(fixedText2)) { // heuristic to detect MathJax, only runs in a browser, not ISO
+      if (!(typeof document === "undefined")) { 
         return (
           <MathJax>
             <div className="c-clientmarkup" dangerouslySetInnerHTML={{__html: fixedText2}}/>

--- a/app/jsx/pages/PageBase.jsx
+++ b/app/jsx/pages/PageBase.jsx
@@ -27,7 +27,7 @@ let sessionStorage = (typeof window != "undefined") ? window.sessionStorage : nu
 
 const mathjaxConfig = {
   startup: {
-    typeset: false
+    typeset: true
   },
   "fast-preview": {
     disabled: true

--- a/app/jsx/pages/PageBase.jsx
+++ b/app/jsx/pages/PageBase.jsx
@@ -35,11 +35,11 @@ const mathjaxConfig = {
   tex: {
     packages: { "[+]": ["html"] },
     inlineMath: [
-      ["$", "$"],
+      ["$$", "$$"],
       ["\\(", "\\)"]
     ],
     displayMath: [
-      ["$$", "$$"],
+      ["$$$", "$$$"],
       ["\\[", "\\]"]
     ]
   },


### PR DESCRIPTION
- re-enbable typesetting of math content on page load, which is default MathJax
- abandon use of regex the conditionally render MathJax, no longer needed
- use new delimiters for MathJax