### PR TITLE
Get rid of SOCKS-mysql kludge

### DIFF
--- a/app/socksMysql.rb
+++ b/app/socksMysql.rb
@@ -60,19 +60,11 @@ class SocksMysql
 
   #################################################################################################
   def bidiTransfer(localSock, remoteSock)
-    first = true
     while true
       rds, wrs, ers = IO.select([localSock, remoteSock], [])
       rds.each { |r|
         data = r.recv(8192)
         data.empty? and return
-        if first
-          # Kludge alert! I can't figure out why, but sometimes we miss the first four bytes of the
-          # server's initial response. A correct response seems to always start with these, so add
-          # them back in.
-          !data.start_with? "N\x00\x00\x00" and data = "N\x00\x00\x00" + data
-          first = false
-        end
         #puts "Tranferring data from #{r == localSock ? "local" : r == remoteSock ? "remote" : r}: #{data.inspect}"
         (r == remoteSock ? localSock : remoteSock).write(data)
       }


### PR DESCRIPTION
The kludge broke compatibility with MySQL 8.0 and appears to not be needed with 5.7 either. Tested with dev (8.0) and stg (5.7).