### PR TITLE
Remove the non-working cleanup code from SocksMysql.initialize, and add a cleanup to pre-destroy and pre-stop events in the Landofile

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -62,6 +62,9 @@ services:
 events:
   pre-destroy:
     - appserver: rm -Rf /app/gems/*
+    - appserver: rm -f /app/.mysqlpsk.3306.*
+  pre-stop:
+    - appserver: rm -f /app/.mysqlpsk.3306.*
   post-start:
     - appserver: test -e ~/.ssh/config || printf 'Host *\n  AddKeysToAgent yes\n' > ~/.ssh/config
 

--- a/app/socksMysql.rb
+++ b/app/socksMysql.rb
@@ -18,14 +18,6 @@ class SocksMysql
     timestamp = Time.now.to_f
     @sockName = ".mysqlpsk.#{@port}.#{Process.getpgrp}.#{timestamp}"
 
-    # Blow away obsolete sockets from prior runs
-    Dir.glob(".mysqlpsk.#{@port}.*").each { |fn|
-      fn =~ /\.mysqlpsk\.\d+\.(\d+)/
-      next if Process.getpgrp == $1.to_i
-      puts "Deleting obsolete #{fn}."
-      File.delete(fn)
-    }
-
     # Fire up a thread to create and service the Unix socket we'll use to proxy MySQL traffic
     ready = Queue.new
     Thread.new { self.service(ready) }


### PR DESCRIPTION
fixes PUBD-686