### PR TITLE
PUBD-736 Add and use ESCHOL_API_ACCESS_KEY if necessary to access dev or stg API

### DIFF
--- a/app/server.rb
+++ b/app/server.rb
@@ -1257,7 +1257,7 @@ def submitAPIMutation(mutation, vars)
   api_access_key = getEnv("ESCHOL_API_ACCESS_KEY")
   headers = { 'Content-Type' => 'application/json',
               'Privileged' => getEnv("ESCHOL_PRIV_API_KEY") }
-  if (api_access_key||0 != 0)
+  unless (api_access_key.to_s == '')
     response = HTTParty.post("#{$escholApiServer}/graphql",
                :headers => headers,
                :query => { access: api_access_key },


### PR DESCRIPTION
Adds and uses a new ENV, ESCHOL_API_ACCESS_KEY. If this ENV is present, it is added to the API request in the submitAPIMutation method. Currently, the only operation in Jschol that uses the submitAPIMutation method is the withdrawal request, which is what PUBD-736 concerns. However, if other uses of the submitAPIMutation are added in the future, they will also benefit from this addition.  ESCHOL_API_ACCESS_KEY is not required on prd, only dev and stg need it.

Big thanks to @everreau for working with me on this solution! We tried **many** different ways to get the access key in to the API request, and finally found the right way to do it.