### PR TITLE
use html component for preferred citation

### DIFF
--- a/app/jsx/components/TabAuthorComp.jsx
+++ b/app/jsx/components/TabAuthorComp.jsx
@@ -313,7 +313,7 @@ class TabAuthorComp extends React.Component {
           <dl className="c-descriptionlist">
             {p.attrs['custom_citation'] &&
                 [<dt key="dt-custom">Preferred:</dt>,
-                 <dd key="dd-custom">{p.attrs['custom_citation']}</dd>]
+                <dd key="dd-custom"><ArbitraryHTMLComp html={p.attrs['custom_citation']}/></dd>]
             }
 
             <dt key="dt-apa">Suggested:</dt>


### PR DESCRIPTION
- preferred citations were displayed with escaped characters instead of as html.  Citations need html.