### PR TITLE
filter out the long pause from the deprecation notice in the nodesource installer

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -32,7 +32,7 @@ services:
     build_as_root:
       - apt-get update -qq && apt-get install -y apt-transport-https && apt-get install glibc-source
       - apt-get install -y phantomjs vim net-tools
-      - curl -sL https://deb.nodesource.com/setup_16.x | bash -
+      - curl -sL https://deb.nodesource.com/setup_16.x | grep -v sleep | bash -
       - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
       - echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
       - apt-get update -qq

--- a/.platform/hooks/prebuild/nodein.sh
+++ b/.platform/hooks/prebuild/nodein.sh
@@ -4,7 +4,7 @@ echo "Trying to install node.";
 #app="$(/opt/elasticbeanstalk/bin/get-config container -k app_staging_dir)";
 app = "/var/app/staging"
 # install node 16 (and npm that comes with it)
-curl --silent --location https://rpm.nodesource.com/setup_16.x | bash -;
+curl --silent --location https://rpm.nodesource.com/setup_16.x | grep -v sleep | bash -;
 sudo yum -y install nodejs
 
 # use npm to install the app's node modules


### PR DESCRIPTION
The nodesource installer for installing Node 16 contains a deprecation notice, and a long pause. We have noted this deprecation notice and will work on upgrading, but in the mean time, we'd like to avoid the long pause.
