### PR TITLE
PUBD-1333 Swap uclalaw policy statement URL in test_unitStatic for ucr_plantpathmicro's policy statement URL

### DIFF
--- a/test/quick.rb
+++ b/test/quick.rb
@@ -68,8 +68,8 @@ class TestQuick < Test::Unit::TestCase
   end
 
   def test_unitStatic
-    html = fetchAndStrip("#{SCHEME}://#{TARGET_HOST}:#{PUMA_PORT}/uc/uclalaw/policyStatement?#{URL_PARAMS}")
-    assert_match(/School of Law only publishes materials about/, html)
+    html = fetchAndStrip("#{SCHEME}://#{TARGET_HOST}:#{PUMA_PORT}/uc/ucr_plantpathmicro/policyStatement?#{URL_PARAMS}")
+    assert_match(/Microbiology and Plant Pathology only publishes materials about/, html)
   end
 
   def test_rootStatic


### PR DESCRIPTION
This PR changes out the URL used for the test_unitStatic test in the JSchol quick test suite. This ucr_plantpathmicro URL is currently the same on dev/stg/prd, and is thus better suited for this test.