### PR TITLE
PUBD-1327 Sort the series selectorList by the ordering column

### DIFF
--- a/app/jsx/layouts/SeriesLayout.jsx
+++ b/app/jsx/layouts/SeriesLayout.jsx
@@ -96,7 +96,7 @@ class SeriesLayout extends React.Component {
   render() {
     let data = this.props.data,
         unit = this.props.unit,
-        selectorList = data.series.filter(function(s){ return (s.unit_id != unit.id) }),
+        selectorList = data.series.filter(function(s){ return (s.unit_id != unit.id) }).sort((a, b) => Number(a.ordering) - Number(b.ordering)),
         formName = "seriesForm",
         formButton = "series-form-submit"
     return (


### PR DESCRIPTION
Since the ordering column is present in the series selectorList props, let's use it to order the selectorList data. Fixes PUBD-1327.