### PR TITLE
Add devbox config

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,87 @@
+# .envrc congifuration for jschol
+
+# WARNING: be sure to point at ONLY dev or stg for everything below... if you 
+# change from dev to stg or vice versa, *everything* needs to match. Recheck this,
+# you probably missed something if this isn't working the way you expect.
+
+### PUMA Configuration ###
+export PUMA_PORT=18880
+export PUMA_THREADS=5 # 5 is the default
+export PUMA_WORKERS=1 # a single worker is a good idea for a dev environment
+
+### ISO Configuration ###
+export ISO_PORT=4002
+
+# ### USE THE OJS DB ON THE DEV SERVER (uncomment to use, and also set USE_SOCKS_FOR_MYSQL=true, and pick the right SOCKS_TARGET)
+# export OJS_DB_HOST=ojs-host-dev
+# export OJS_DB_PORT='3306'
+# export OJS_DB_DATABASE=ojs
+# export OJS_DB_USERNAME=ojsuser
+# export OJS_DB_PASSWORD=ojspassword
+
+### USE THE OJS DB ON THE STG SERVER (uncomment to use, and also set USE_SOCKS_FOR_MYSQL=true, and pick the right SOCKS_TARGET)
+export OJS_DB_HOST=ojs-host-stg
+export OJS_DB_PORT='3306'
+export OJS_DB_DATABASE=ojs
+export OJS_DB_USERNAME=ojsuser
+export OJS_DB_PASSWORD=ojspassword
+
+
+### USE THE ESCHOL DB ON THE STG SERVER (uncomment to use, and also set USE_SOCKS_FOR_MYSQL=true, and pick the right SOCKS_TARGET)
+### WARNING: if you want to point to dev, you need to change ALL urls below that mention 'stg' to 'dev'
+### ALSO: use the dev DBs above, not the stg ones
+export ESCHOL_DB_HOST=eschol-host-stg
+export ESCHOL_DB_PORT='3306'
+export ESCHOL_DB_DATABASE=eschol_test
+export ESCHOL_DB_USERNAME=escholuser
+export ESCHOL_DB_PASSWORD='eschol-password'
+
+###############################################################################
+export JSCHOL_KEY=jschol-key
+
+###############################################################################
+export MRTEXPRESS_HOST=mrtexpress-host
+export MRTEXPRESS_USERNAME=mrtexpress-user
+export MRTEXPRESS_PASSWORD=mrtexpress-password
+
+###############################################################################
+export S3_BUCKET=s3-bucket
+export S3_REGION=s3-region
+export S3_BINARIES_PREFIX=s3-binaries-prefix
+export S3_PATCHES_PREFIX=s3-patches-prefix
+export S3_CONTENT_PREFIX=s3-content-prefix
+export S3_PREVIEW_PREFIX=s3-preview-prefix
+
+###############################################################################
+export ESCHOL_API_SERVER=eschol-api-server
+export ESCHOL_PRIV_API_KEY=eschol-priv-api-key
+export ESCHOL_API_ACCESS_KEY=eschol-api-access-key
+#
+# ###############################################################################
+# export THUMBNAIL_SERVER=thumbnail-server
+# export PEOPLE_ARK_SHOULDER=people-ark-shoulder
+#
+# ###############################################################################
+# CAREFUL! Use values for cloudsearch that match your SOCKS settings below 
+# export CLOUDSEARCH_DOMAIN=cloudsearch-domain-dev
+# export CLOUDSEARCH_SEARCH_ENDPOINT=cloudsearch-search-endpoint-dev
+# export CLOUDSEARCH_DOC_ENDPOINT=cloudsearch-doc-endpoint-dev
+export CLOUDSEARCH_DOMAIN=cloudsearch-domain-stg
+export CLOUDSEARCH_SEARCH_ENDPOINT=cloudsearch-search-endpoint-stg
+export CLOUDSEARCH_DOC_ENDPOINT=cloudsearch-doc-endpoint-stg
+
+###############################################################################
+export SOCKS_PORT=1081
+export SOCKS_USER=your-user-name
+export SOCKS_TARGET=submit-stg-is-probably-a-good-choice
+export SOCKS_BASTION=our-bastion-domain
+export SOCKS_BASTION_PORT=our-bastion-ssl-port
+export SOCKS_KEYPATH=/path/to/your/ssh/key
+export USE_SOCKS_FOR_MYSQL=true # set to false if running MySQL locally
+
+###############################################################################
+# Ruby Options help us tune out some noise
+export RUBYOPT='-W:no-deprecated -W:no-experimental'
+
+#### extra stuff ###
+

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ local.env
 .lando.local.yml
 config/puma.rb
 dev/puma.rb
+.envrc

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Description of files
   our [AWS CLI Cheatsheet](https://github.com/cdlib/pad-sys-doc/blob/main/cheatsheet/aws-cli.md).
 * `overlay_files` folder for beanstalk app overlays, used by the deployVersion.sh script. You'll want to grab the contents of this folder from the `pub-cattle2-ops` ec2 instance, if you want to deploy from your Lando dev environment.
 
+Lando Dev Environment
+---------------------
+
 Steps to get the app running on your local machine, with Lando
 1. Make sure [Lando](https://lando.dev/) is installed
  * Lando comes bundled with Docker Desktop, if you already have Docker Desktop installed, don't re-install it, just ensure you have the same version as what is bundled with Lando.
@@ -70,7 +73,29 @@ Steps to get the app running on your local machine, with Lando
 This Lando dev environment includes a local MySQL server, which can load MySQL dumps from dev, stg or prd. To load a dump file, run
 1. `lando db-import name-of-mysql-dump-file.gz`
 
-NOTE: if you do not have a dump file, ask Hardy, he can lend you a somewhat recent one. Or, you can rely on the SOCKS connection to use the db on one of our servers. Or you can use the VPN.
+NOTE: if you do not have a dump file, ask Hardy, he can lend you a somewhat
+recent one. Or, you can rely on the SOCKS connection to use the db on one of our
+servers. Or you can use the VPN.
+
+Devbox + Direnv Dev Environment
+----------------------
+
+Steps to get the app running on your local machine, with Devbox
+1. Make sure [Devbox](https://www.jetify.com/devbox/docs/quickstart/) is
+   installed
+2. Also install [Direnv](https://direnv.net/) if it isn't already
+3. Copy `.envrc.example` to `.envrc` and customize as appropriate
+4. `devbox shell` downloads requirements and launches a devbox development environment 
+5. After your devbox shell is open, run the `setup.sh` script to finish
+   installing JSchol
+6. Run `./gulp`. Be on the lookout for errors. 
+
+NOTE: The first time you run `devbox shell` may take a while to complete due to 
+Devbox downloading prerequisites and package catalogs required by Nix. This 
+delay is a one-time cost, and future invocations and package additions should 
+resolve much faster.
+
+Using the Devbox environment is roughly equivalent to [running the application natively](#Running-the-application-natively).
 
 Troubleshooting
 ---------------
@@ -98,8 +123,11 @@ Tooling
 More [tooling](https://docs.lando.dev/config/tooling.html) can be added easily.
 
 
-Steps to get the app running on your local machine without Lando
-----------------------------------------------------------------
+Running the application natively
+--------------------------------
+
+Steps to get the app running on your local machine without Lando or Devbox
+
 1. Make sure these are installed:
  * bundler
  * ruby

--- a/README.md
+++ b/README.md
@@ -95,7 +95,25 @@ Devbox downloading prerequisites and package catalogs required by Nix. This
 delay is a one-time cost, and future invocations and package additions should 
 resolve much faster.
 
-Using the Devbox environment is roughly equivalent to [running the application natively](#Running-the-application-natively).
+After you sucessfully run gulp the first time, you can use devbox tooling to
+start up the jschol service:
+
+```bash
+devbox services up jschol
+```
+the above command will start up a process-compose session of the JSchol
+application, you can then visit http://localhost:18880 to visit the running
+Jschol application on your own computer.
+
+To run the quicktest, after you have Jschol running in a process-compose session
+(described above), you can run this command in another shell:
+```bash
+devbox run test
+```
+
+OR you can run the quicktest as you would in a native dev environment. In fact,
+using the Devbox environment can be roughly equivalent to [running the application
+natively](#Running-the-application-natively). If you prefer that style of work.
 
 Troubleshooting
 ---------------

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Steps to get the app running on your local machine, with Lando
 This Lando dev environment includes a local MySQL server, which can load MySQL dumps from dev, stg or prd. To load a dump file, run
 1. `lando db-import name-of-mysql-dump-file.gz`
 
-NOTE: if you do not have a dump file, ask Hardy, he can lend you a somewhat
+NOTE: if you do not have a dump file, ask around, we can lend you a somewhat
 recent one. Or, you can rely on the SOCKS connection to use the db on one of our
 servers. Or you can use the VPN.
 

--- a/app/scss/_editable.scss
+++ b/app/scss/_editable.scss
@@ -167,7 +167,7 @@
   $can-toggle-shadow: 0 3px 3px rgba(black, 0.4)
 )
 {
-  $can-toggle-switch-width: $can-toggle-width/2;
+  $can-toggle-switch-width: calc($can-toggle-width/2);
   
   input[type="checkbox"] {
 
@@ -201,16 +201,16 @@
       border-radius: $can-toggle-border-radius;
       
       &:before {
-        left: $can-toggle-width/2;
+        left: calc($can-toggle-width/2);
         font-size: $can-toggle-switch-font-size; 
         line-height: $can-toggle-height;
-        width: $can-toggle-width/2;
+        width: calc($can-toggle-width/2);
         padding: 0 12px;
       }
       
       &:after {
         top: $can-toggle-offset; left: $can-toggle-offset;
-        border-radius: $can-toggle-border-radius/2;
+        border-radius: calc($can-toggle-border-radius/2);
         width: $can-toggle-switch-width - $can-toggle-offset; 
         line-height: $can-toggle-height - ($can-toggle-offset*2);
         font-size: $can-toggle-switch-font-size;

--- a/app/scss/_jump.scss
+++ b/app/scss/_jump.scss
@@ -18,7 +18,7 @@ $jump-list-spacing: 0.5em;
 
   li {
     margin-left: $spacing-sm;
-    padding: $jump-list-spacing/2 0 $jump-list-spacing $spacing-md;
+    padding: calc($jump-list-spacing / 2) 0 $jump-list-spacing $spacing-md;
     // CSS-only tree drawing ideas from: https://two-wrongs.com/draw-a-tree-structure-with-only-css
     position: relative;
     &::before, &::after {

--- a/app/scss/_tabcontent.scss
+++ b/app/scss/_tabcontent.scss
@@ -28,11 +28,11 @@
     width: 50%;
 
     &:first-child {
-      padding-right: $spacing-md / 2;
+      padding-right: calc($spacing-md / 2);
     }
 
     &:last-child {
-      padding-left: $spacing-md / 2;
+      padding-left: calc($spacing-md / 2);
     }
 
   }

--- a/app/scss/_teaser.scss
+++ b/app/scss/_teaser.scss
@@ -17,7 +17,7 @@
     background-color: $color-light-teal;
 
     &:first-child {
-      margin-bottom: $spacing-sm / 2;
+      margin-bottom: calc(#{$spacing-sm} / 2);
     }
 
     @include bp(screen3) {
@@ -26,12 +26,12 @@
       padding: $spacing-lg;
 
       &:first-child {
-        margin-right: $spacing-sm / 2;
+        margin-right: calc(#{$spacing-sm} / 2);
         margin-bottom: 0;
       }
 
       &:last-child {
-        margin-left: $spacing-sm / 2;
+        margin-left: calc(#{$spacing-sm} / 2);
       }
 
     }

--- a/app/scss/_utilities.scss
+++ b/app/scss/_utilities.scss
@@ -225,7 +225,7 @@ Background color with progressively-enhanced blur effect. Example:
 // Fluid text mixin courtesy of: https://css-tricks.com/snippets/css/fluid-typography/
 
 @function strip-unit($value) {
-  @return $value / ($value * 0 + 1);
+  @return calc(#{$value} / (#{$value} * 0 + 1));
 }
 
 @mixin u-fluid-type($min-vw, $max-vw, $min-font-size, $max-font-size) {

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.12.0/.schema/devbox.schema.json",
+  "packages": {
+    "ruby":    "3.0",
+    "nodejs":  "18.19.1",
+    "mysql-client": "latest",
+    "openssl": {
+      "version": "latest",
+      "outputs": ["out", "dev"]
+    },
+    "zstd": {
+      "version": "latest",
+      "outputs": ["out", "dev"]
+    },
+    "mysql80": {
+      "version": "latest",
+      "outputs": ["out", "dev"]
+    }
+  },
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to devbox!' > /dev/null"
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/devbox.json
+++ b/devbox.json
@@ -23,7 +23,7 @@
     ],
     "scripts": {
       "test": [
-        "echo \"Error: no test specified\" && exit 1"
+        "bundle exec rubocop && npx eslint . && ruby tools/maybeSocks.rb && ruby test/quick.rb"
       ]
     }
   }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,430 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "mysql-client@latest": {
+      "last_modified": "2023-02-24T09:01:09Z",
+      "resolved": "github:NixOS/nixpkgs/7d0ed7f2e5aea07ab22ccb338d27fbe347ed2f11#mysql-client",
+      "source": "devbox-search",
+      "version": "10.6.12"
+    },
+    "mysql80@latest": {
+      "last_modified": "2024-06-12T20:55:33Z",
+      "plugin_version": "0.0.3",
+      "resolved": "github:NixOS/nixpkgs/a9858885e197f984d92d7fe64e9fff6b2e488d40#mysql80",
+      "source": "devbox-search",
+      "version": "8.0.36",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/81mx0nmi7cm91dndzvd58adnf6c7bqvk-mysql-8.0.36",
+              "default": true
+            },
+            {
+              "name": "static",
+              "path": "/nix/store/jnmd218abi86mmqgnqg48jivgk3bqjz0-mysql-8.0.36-static"
+            }
+          ],
+          "store_path": "/nix/store/81mx0nmi7cm91dndzvd58adnf6c7bqvk-mysql-8.0.36"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hsmwbs2pb3wq866gcf3vwdvz11xaf6r1-mysql-8.0.36",
+              "default": true
+            },
+            {
+              "name": "static",
+              "path": "/nix/store/v08l0gw4cc62scyvj6mw6yb2m1x8qs9h-mysql-8.0.36-static"
+            }
+          ],
+          "store_path": "/nix/store/hsmwbs2pb3wq866gcf3vwdvz11xaf6r1-mysql-8.0.36"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/02kjcr7d9gbly0d001y5n30cs2s0j8lc-mysql-8.0.36",
+              "default": true
+            },
+            {
+              "name": "static",
+              "path": "/nix/store/5xddij71kfxpr8i4bzh66d1f53knhdwk-mysql-8.0.36-static"
+            }
+          ],
+          "store_path": "/nix/store/02kjcr7d9gbly0d001y5n30cs2s0j8lc-mysql-8.0.36"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/plqgv09pfmp7rkf9vi1im2np1f2hff9l-mysql-8.0.36",
+              "default": true
+            },
+            {
+              "name": "static",
+              "path": "/nix/store/3knq9q4n7frdj0vy20bz1aywyiwv1rm2-mysql-8.0.36-static"
+            }
+          ],
+          "store_path": "/nix/store/plqgv09pfmp7rkf9vi1im2np1f2hff9l-mysql-8.0.36"
+        }
+      }
+    },
+    "nodejs@18.19.1": {
+      "last_modified": "2024-04-02T02:53:36Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/080a4a27f206d07724b88da096e27ef63401a504#nodejs_18",
+      "source": "devbox-search",
+      "version": "18.19.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wrhcjmwsffb2fj95fxfcnq8k7f3i6xbx-nodejs-18.19.1",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/99279y3njrascwlai7d614vdqm5mi8mr-nodejs-18.19.1-libv8"
+            }
+          ],
+          "store_path": "/nix/store/wrhcjmwsffb2fj95fxfcnq8k7f3i6xbx-nodejs-18.19.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/0bsi7d89gcvijqjamf0yprydrw62zf4i-nodejs-18.19.1",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/wcdlnd8jl36fxv6mp9n7hg9240aglzg7-nodejs-18.19.1-libv8"
+            }
+          ],
+          "store_path": "/nix/store/0bsi7d89gcvijqjamf0yprydrw62zf4i-nodejs-18.19.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/d2hhvc8z1dxscrdznmfb8x6plgnfv1cj-nodejs-18.19.1",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/bf6cbi9cb05x6ni9aizvys4az2k4whxk-nodejs-18.19.1-libv8"
+            }
+          ],
+          "store_path": "/nix/store/d2hhvc8z1dxscrdznmfb8x6plgnfv1cj-nodejs-18.19.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/r1f216x7zryxxqzf45j4ss1m3amh5sy0-nodejs-18.19.1",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/629bsljr46jxxl6790qxk7aa81qsi6dg-nodejs-18.19.1-libv8"
+            }
+          ],
+          "store_path": "/nix/store/r1f216x7zryxxqzf45j4ss1m3amh5sy0-nodejs-18.19.1"
+        }
+      }
+    },
+    "openssl@latest": {
+      "last_modified": "2024-06-27T06:07:08Z",
+      "resolved": "github:NixOS/nixpkgs/1e3deb3d8a86a870d925760db1a5adecc64d329d#openssl",
+      "source": "devbox-search",
+      "version": "3.0.13",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/ka3xjddzaplz4j9s8ccdvrrmx060pi06-openssl-3.0.13-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/knyqdlsbp93say8x440lzxpfzw6dy2md-openssl-3.0.13-man",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/bc10sl6fda9mb598n3gld2fwqr24zq7p-openssl-3.0.13"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/r9dm9dhafnipff77yl4bv1ncjgh4afsi-openssl-3.0.13-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/dcgz9smb78ymwnpfk4pw8y66jl30cjw7-openssl-3.0.13-doc"
+            }
+          ],
+          "store_path": "/nix/store/ka3xjddzaplz4j9s8ccdvrrmx060pi06-openssl-3.0.13-bin"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/i0mly410wz8sn1xmvyh0dhk28hz0bvpd-openssl-3.0.13-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/dl2p8yf7d5n2c4j2w97z3zfflhdby9qa-openssl-3.0.13-man",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/79133n8bg94fbvn37bmxlgjiii64mn9x-openssl-3.0.13-debug"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/znh18bsvgl91k16z7rsjpm9zz3kyqxfp-openssl-3.0.13-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/q402mm7rzi0za58dwwsfml52b9g19jc0-openssl-3.0.13-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/a3kd6468fz5fldax5iiw985gvbzl6srw-openssl-3.0.13"
+            }
+          ],
+          "store_path": "/nix/store/i0mly410wz8sn1xmvyh0dhk28hz0bvpd-openssl-3.0.13-bin"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/ygqgkllvfnxnnp9lgjbisbssir1pxks7-openssl-3.0.13-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/ir5p7x4y6cd0rlh5q6myad8srd4zx8cv-openssl-3.0.13-man",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/g00c06vnvkyha3c32l3jaz3ix9a2sypm-openssl-3.0.13"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/h7q6vjnflr4f3x4gfxd3iqzbklhkdm72-openssl-3.0.13-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/ygbh6mcqh6kamx77j59dg5lyk72fazzk-openssl-3.0.13-doc"
+            }
+          ],
+          "store_path": "/nix/store/ygqgkllvfnxnnp9lgjbisbssir1pxks7-openssl-3.0.13-bin"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/3cmxly54pvpv20m6cfpj96j18w8gbp02-openssl-3.0.13-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/kghplhw0z70f1wkamb7kxp8s6w2nb4w7-openssl-3.0.13-man",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/d7lx2hv9chx1mzryrr0ach55fljbhglv-openssl-3.0.13-debug"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/dz2mjwyvs1l3vvvp5izx0xpxq1vvw075-openssl-3.0.13-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/xcbsfs6a4d6cnqyvlk5z1h99d3cyc6kk-openssl-3.0.13-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/8bdd933v69w05k5v8hfcq74bi1f9545k-openssl-3.0.13"
+            }
+          ],
+          "store_path": "/nix/store/3cmxly54pvpv20m6cfpj96j18w8gbp02-openssl-3.0.13-bin"
+        }
+      }
+    },
+    "ruby@3.0": {
+      "last_modified": "2023-11-17T14:14:56Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/a71323f68d4377d12c04a5410e214495ec598d4c#ruby_3_0",
+      "source": "devbox-search",
+      "version": "3.0.6",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/pa96sc1vv69k7rwn2nsrlh9dappq8838-ruby-3.0.6",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/70716j1lq697hbji1h68fgzxa1hvik9y-ruby-3.0.6-devdoc"
+            }
+          ],
+          "store_path": "/nix/store/pa96sc1vv69k7rwn2nsrlh9dappq8838-ruby-3.0.6"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/87apbcglg24xm8z62h3izxkhi8ndaks9-ruby-3.0.6",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/snkg2zr346jpf263ix5wrwlx7dqwhxf9-ruby-3.0.6-devdoc"
+            }
+          ],
+          "store_path": "/nix/store/87apbcglg24xm8z62h3izxkhi8ndaks9-ruby-3.0.6"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/zhb16baxghaaapyc6bp8x0sqqpr0bsn4-ruby-3.0.6",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/k71ridrl2v0hfx0n0m85nwvg2l6nhbbk-ruby-3.0.6-devdoc"
+            }
+          ],
+          "store_path": "/nix/store/zhb16baxghaaapyc6bp8x0sqqpr0bsn4-ruby-3.0.6"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/2wncs3b3ysh8gi8zbkdyn0dpjv0bd2k4-ruby-3.0.6",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/s0pgpf3lmz99647h3rwaa0zj0vmhjh4q-ruby-3.0.6-devdoc"
+            }
+          ],
+          "store_path": "/nix/store/2wncs3b3ysh8gi8zbkdyn0dpjv0bd2k4-ruby-3.0.6"
+        }
+      }
+    },
+    "zstd@latest": {
+      "last_modified": "2024-06-27T06:07:08Z",
+      "resolved": "github:NixOS/nixpkgs/1e3deb3d8a86a870d925760db1a5adecc64d329d#zstd",
+      "source": "devbox-search",
+      "version": "1.5.6",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/4k1x14dk2mn5v1kag22kzlxzr3n9ak36-zstd-1.5.6-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/32imn4mkyaysnd271hfb4cr9hljfhh2p-zstd-1.5.6-man",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/38z0bsp6xw3vvqjd86z75nrsv4lf1bqs-zstd-1.5.6"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/gy55m5myy53xjfciqrv7d029l5j6dvyk-zstd-1.5.6-dev"
+            }
+          ],
+          "store_path": "/nix/store/4k1x14dk2mn5v1kag22kzlxzr3n9ak36-zstd-1.5.6-bin"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/gv1199cs89fjxy7hdvq4bl0bxpmbab19-zstd-1.5.6-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/n6srqk9y684h2qazyy3bwacqzpch87q1-zstd-1.5.6-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/66b36wbm0rialh0fn547dgvkndyw6vix-zstd-1.5.6-dev"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/d628xm03pk2ywbm9mf651517anqx701z-zstd-1.5.6"
+            }
+          ],
+          "store_path": "/nix/store/gv1199cs89fjxy7hdvq4bl0bxpmbab19-zstd-1.5.6-bin"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/zy1bkchhs83n3i8b0qw0lq8gmr2vxc86-zstd-1.5.6-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/9bkm6k86gixsqmawk664s0ln3viv1yrf-zstd-1.5.6-man",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/sxw9vk2fhidsqc3wbqzzhy9xsbh0jcfp-zstd-1.5.6"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/xfq9bmd0sndanbyr8fi8isd0bg9y5v1l-zstd-1.5.6-dev"
+            }
+          ],
+          "store_path": "/nix/store/zy1bkchhs83n3i8b0qw0lq8gmr2vxc86-zstd-1.5.6-bin"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/gsrsyrcqscmq7yq54gyc7xsr3mfwvj1k-zstd-1.5.6-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/rz6n6kkl5ij5qs9iqf9isifslxzmhvq9-zstd-1.5.6-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/4i4z8z68605bjs91mkshqhmnpn8bxwmb-zstd-1.5.6-dev"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/sdv9z5jh502gwyh9m959ya6a2pc8skrk-zstd-1.5.6"
+            }
+          ],
+          "store_path": "/nix/store/gsrsyrcqscmq7yq54gyc7xsr3mfwvj1k-zstd-1.5.6-bin"
+        }
+      }
+    }
+  }
+}

--- a/process-compose.yml
+++ b/process-compose.yml
@@ -1,0 +1,19 @@
+# Process compose for starting the Jschol service
+version: "0.5"
+
+processes:
+  jschol:
+   command: "rm .mysqlpsk.3306.* || ./gulp"
+   availability:
+    restart: "always"
+    readiness_probe:
+      http_get:
+        host: 127.0.0.1
+        scheme: http
+        path: "/"
+        port: 18880
+      initial_delay_seconds: 30
+      period_seconds: 10
+      timeout_seconds: 5
+      success_threshold: 1
+      failure_threshold: 3

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
-# If an error occurs, stop this script
-set -e
+# use bash strict mode
+set -euo pipefail
+IFS=$'\n\t'
+
+# uncomment for debug
+#set -x
 
 printf "== Installing local Ruby gems ==\n"
 gem install bundler
@@ -11,13 +15,11 @@ bundle install --quiet --path=gems --binstubs
 bundle clean
 
 printf "\n== Installing node packages (used by gulp and iso via Node) ==\n"
-npm install npm@10.8.1
+npm install npm@10.2.4
 npm install
 npm install gulp-cli # shouldn't be necessary, but seems to be
 
-if [[ `/bin/hostname` == "*pub-submit*" ]]; then
-  printf "\n== Building splash page generator ==\n"
-  cd splash
-  ./setupSplash.sh
-  cd ..
+# add a symlink to node_modules/.bin/gulp in the root directory, if necessary
+if [ ! -L ./gulp ]; then
+  ln -s node_modules/.bin/gulp ./gulp
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -15,7 +15,7 @@ bundle install --quiet --path=gems --binstubs
 bundle clean
 
 printf "\n== Installing node packages (used by gulp and iso via Node) ==\n"
-npm install npm@10.2.4
+npm install npm@10.8.1
 npm install
 npm install gulp-cli # shouldn't be necessary, but seems to be
 

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,7 @@
 set -e
 
 printf "== Installing local Ruby gems ==\n"
+gem install bundler
 bundle install --quiet --path=gems --binstubs
 
 #printf "\n== Uninstalling Ruby gems no longer used ==\n"


### PR DESCRIPTION
Adds configuration and changes a few things to facilitate using [Jetify Devbox](https://www.jetify.com/devbox) as a dev environment for JSchol. Also contains some changes to SCSS files to handle some deprecation warnings that we see during deploys and while running the dev environment.