### PR TITLE
PUBD-1311 make default sort order more reasonable

### DIFF
--- a/app/unitPages.rb
+++ b/app/unitPages.rb
@@ -502,10 +502,10 @@ def getSeriesLandingPageData(unit, q)
 
   defaultSortOrder = 'desc'
 
-  # Infer the sort order from the children's ordering property
-  children_orderings = children.map { |child| child[:ordering] }
-
-  if children_orderings.any?
+  # PUBD-1311 KLUDGE ALERT: hard code the sort order for any unit id that begins
+  # with ucsd_jn_  to be by title
+  # This is a temporary fix until we can add a sort order field to the unit data
+  if unit.id.start_with?('ucsd_jn_')
     defaultSortOrder = 'a-title'
   end
 

--- a/app/unitPages.rb
+++ b/app/unitPages.rb
@@ -500,9 +500,19 @@ def getSeriesLandingPageData(unit, q)
     children = parent ? $hierByAncestor[parent[0].ancestor_unit] : []
   end
 
-  response = unitSearch(q ? q : {"sort" => ['desc']}, unit)
+  defaultSortOrder = 'desc'
+
+  # Infer the sort order from the children's ordering property
+  children_orderings = children.map { |child| child[:ordering] }
+
+  if children_orderings.any?
+    defaultSortOrder = 'a-title'
+  end
+
+  response = unitSearch(q ? q : {"sort" => [defaultSortOrder]}, unit)
   response[:series] = children ? (children.select { |u| u.unit.type == 'series' } + 
     children.select { |u| u.unit.type == 'monograph_series' }).map { |u| seriesPreview(u) } : []
+
   return response
 end
 


### PR DESCRIPTION
This is a draft/work in progress, I'll mark it as so, and will let you know when it's ready to merge. As it is currently written, it uses the unit_id (any unit_id that starts with ucsd_jn_") to trigger a change from the default 'desc' sort order on series pages. This is a temporary fix, we'll need to add a "default_sort" field to unit properties, and then use it set the default sort for the unit.