### PR TITLE
Add cloudwatch config for memory stats

### DIFF
--- a/.ebextensions/cloudwatch.config
+++ b/.ebextensions/cloudwatch.config
@@ -6,13 +6,14 @@ files:
     content: |
       {
         "agent": {
-          "metrics_collection_interval": 60,
+          "metrics_collection_interval": 30,
           "run_as_user": "root"
         },
         "metrics": {
           "namespace": "System/Linux",
           "append_dimensions": {
-            "AutoScalingGroupName": "${aws:AutoScalingGroupName}"
+            "AutoScalingGroupName": "${aws:AutoScalingGroupName}",
+            "InstanceId": "${aws:InstanceId}",
           },
           "metrics_collected": {
             "mem": {

--- a/.ebextensions/cloudwatch.config
+++ b/.ebextensions/cloudwatch.config
@@ -1,0 +1,28 @@
+files:  
+  "/opt/aws/amazon-cloudwatch-agent/bin/config.json": 
+    mode: "000600"
+    owner: root
+    group: root
+    content: |
+      {
+        "agent": {
+          "metrics_collection_interval": 60,
+          "run_as_user": "root"
+        },
+        "metrics": {
+          "namespace": "System/Linux",
+          "append_dimensions": {
+            "AutoScalingGroupName": "${aws:AutoScalingGroupName}"
+          },
+          "metrics_collected": {
+            "mem": {
+              "measurement": [
+                "mem_used_percent"
+              ]
+            }
+          }
+        }
+      }  
+container_commands:
+  start_cloudwatch_agent: 
+    command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json

--- a/.ebextensions/cloudwatch.config
+++ b/.ebextensions/cloudwatch.config
@@ -13,7 +13,7 @@ files:
           "namespace": "System/Linux",
           "append_dimensions": {
             "AutoScalingGroupName": "${aws:AutoScalingGroupName}",
-            "InstanceId": "${aws:InstanceId}",
+            "InstanceId": "${aws:InstanceId}"
           },
           "metrics_collected": {
             "mem": {


### PR DESCRIPTION
Adds a config file to send used memory percentage cloudwatch so we can track memory usage in the beanstalk instances.

Based on [AWS EB documentation](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customize-containers-cw.html).