### PR TITLE
741 bug search filters reset

### DIFF
--- a/app/jsx/components/FormComp.jsx
+++ b/app/jsx/components/FormComp.jsx
@@ -28,7 +28,15 @@ class FormComp extends React.Component
     }
     else {
       event.preventDefault()
-      this.props.history.push(this.props.to + "?" + $.param(data).replace(/%5B%5D/g, ""))
+
+      const params = new URLSearchParams(window.location.search)
+      debugger
+      // preserve previous data in url 
+      for (const [k, v] of Object.entries(data)) {
+        params.set(k, v)
+      }
+      this.props.history.push(this.props.to + "?" + params.toString().replace(/%5B%5D/g, ""))
+      
     }
   }
 

--- a/app/jsx/components/FormComp.jsx
+++ b/app/jsx/components/FormComp.jsx
@@ -6,8 +6,7 @@ import getFormData from 'get-form-data'
 import $ from 'jquery'
 import { withRouter } from 'react-router'
 
-class FormComp extends React.Component
-{
+class FormComp extends React.Component {
   static propTypes = {
     id: PropTypes.string,
     to: PropTypes.string,      // either 'to' ...
@@ -28,13 +27,17 @@ class FormComp extends React.Component
     }
     else {
       event.preventDefault()
-
       const params = new URLSearchParams(window.location.search)
-      debugger
+     
+      if (!data.start) { // when the page = 1, there's no start param
+        params.delete('start')  // make sure we delete it from previous url
+      }
+      
       // preserve previous data in url 
       for (const [k, v] of Object.entries(data)) {
         params.set(k, v)
       }
+
       this.props.history.push(this.props.to + "?" + params.toString().replace(/%5B%5D/g, ""))
       
     }


### PR DESCRIPTION
Fix for #741. This bug was caused by a form submission (triggered by the page buttons) that refreshed the entire page, resulting in the loss of data filters in the URL.