### PR TITLE
Pubd 509 fix slug

### DIFF
--- a/app/server.rb
+++ b/app/server.rb
@@ -859,7 +859,7 @@ end
 # Global static pages; also, a fallback for global not-found.
 def getGlobalStaticData(path)
   pageName = path.sub(%r{^/}, "")
-  if pageName =~ %r{^[a-zA-Z]([a-zA-Z_]+/)*[a-zA-Z_]+$} && Page.where(unit_id: 'root', slug: pageName).count > 0
+  if pageName =~ %r{^[a-zA-Z0-9]([a-zA-Z0-9_]+/)*[a-zA-Z0-9_]+$} && Page.where(unit_id: 'root', slug: pageName).count > 0
     unit = $unitsHash['root']
     attrs = JSON.parse(unit[:attrs])
     return {

--- a/test/quick.rb
+++ b/test/quick.rb
@@ -211,4 +211,29 @@ class TestQuick < Test::Unit::TestCase
       puts "URL_PARAMS present, skipping test_for_broken_images"
     end
   end
+
+  def test_page_name_regex
+    paths = [
+      { path: "/page5", expected_match: true },
+      { path: "/page_one", expected_match: true },
+      { path: "/page_5/test", expected_match: true },
+      { path: "/anotherPage", expected_match: true },
+      { path: "/123page", expected_match: true },
+      { path: "/page 5", expected_match: false },
+      { path: "/page/5/", expected_match: false },
+      { path: "/!invalid", expected_match: false },
+      { path: "/123 page", expected_match: false },
+      { path: "/page$5", expected_match: false },
+      { path: "/page/5#test", expected_match: false }
+    ]
+
+    paths.each do |entry|
+      page_name = entry[:path].sub(%r{^/}, "")
+      if entry[:expected_match]
+        assert_match(%r{^[a-zA-Z0-9]([a-zA-Z0-9_]+/)*[a-zA-Z0-9_]+$}, page_name, "#{entry[:path]} should be valid")
+      else
+        assert_no_match(%r{^[a-zA-Z0-9]([a-zA-Z0-9_]+/)*[a-zA-Z0-9_]+$}, page_name, "#{entry[:path]} should be invalid")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix for [CMS breaks with numbers in the URL slug (PUBD-509)](https://trello.com/c/tQ8avjdy). When creating a page with a number in the slug, it would return a 404. This updates the regex for valid slugs to also allow alphanumeric characters.