### PR TITLE
styling updates for PDF errors

### DIFF
--- a/app/jsx/components/PdfViewerComp.jsx
+++ b/app/jsx/components/PdfViewerComp.jsx
@@ -327,6 +327,7 @@ export default class PdfViewerComp extends React.Component
         <div id="errorWrapper" hidden='true'>
           <div id="errorMessageLeft">
             <span id="errorMessage"></span>
+            <span>If you recently published this item, please wait up to 30 minutes for the PDF to appear here.</span>
             <button id="errorShowMore" data-l10n-id="error_more_info">
               More Information
             </button>

--- a/app/scss/_pdfview.scss
+++ b/app/scss/_pdfview.scss
@@ -59,3 +59,20 @@
   }
 
 }
+
+#pdfjs-cdl-wrapper #errorWrapper {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  background-color: #ccc;
+  color: #000;
+  font-size: 1.5em;
+}
+
+#errorShowMore, #showErrorLess {
+  display: none;
+}
+
+#pdfjs-cdl-wrapper #errorMessageLeft {
+  padding: 0.5em;
+}


### PR DESCRIPTION
Addresses #715. Updated with Justin's suggestions. 

<img width="917" alt="Screenshot 2025-03-21 at 10 10 15 AM" src="https://github.com/user-attachments/assets/12431d17-9b3b-4bfa-b5fd-a597b51f335e" />

