### PR TITLE
fix newline issue in abstracts

### DIFF
--- a/app/scss/_clientmarkup.scss
+++ b/app/scss/_clientmarkup.scss
@@ -62,5 +62,7 @@
     font-size: 1.1em;
   }
 
+  white-space: pre-wrap;
+
 }
 


### PR DESCRIPTION
Fix for #776. We were rendering the abstract text using React's `dangerouslySetInnerHTML`, but this doesn't automatically interpret newline characters as line breaks. 