### PR TITLE
Improve CMS logo handling

### DIFF
--- a/app/jsx/layouts/UnitProfileLayout.jsx
+++ b/app/jsx/layouts/UnitProfileLayout.jsx
@@ -44,6 +44,9 @@ export const disciplineOptions = [
     { value: "social", label: "Social and Behavioral Sciences" }
 ];
 
+const MAX_LOGO_WIDTH = 800
+const MAX_LOGO_HEIGHT = 90
+
 class UnitProfileLayout extends React.Component {
   // static propTypes = {
   // }
@@ -102,12 +105,27 @@ class UnitProfileLayout extends React.Component {
   }
 
   //handles image preview BEFORE any image is POST'ed to server/BEFORE any asset_id is generated
+  // TODO: 
+  // - accepted dimensions are different for logo and hero -- accomodate both
+  // - dont actually allow user to upload file if it doesnt fit criteria
   handleImageChange = (event) => {
     event.preventDefault()
     let reader = new FileReader()
     let file = event.target.files[0]
     let imgObj = {}
     let fieldName = event.target.name
+
+    // https://stackoverflow.com/a/58897088
+    let img = new Image()
+    console.log(event.target.value)
+    
+    img.src = window.URL.createObjectURL(file)     
+
+    img.onload = () => {
+      if (img.width > MAX_LOGO_WIDTH || img.height > MAX_LOGO_HEIGHT) {
+        alert(`Error: ${img.width}x${img.height} exceeds maximum allowed dimensions of ${MAX_LOGO_WIDTH}x${MAX_LOGO_HEIGHT}`); // change here 
+      }
+    }   
 
     reader.onloadend = () => {
       imgObj[fieldName] = {imagePreviewUrl: reader.result}
@@ -173,6 +191,12 @@ class UnitProfileLayout extends React.Component {
                    { !disableLogo &&
                      <div>
                        <input type="file" id="logoImage" name="logo" onChange={this.handleImageChange}/>
+                       <br/><br/>
+                       <i>Logo requirements: 800px width x 90px height in JPG, PNG, or GIF format. 
+                        <a href="https://help.escholarship.org/support/solutions/articles/9000124100">
+                          See the eScholarship help center for more information.
+                        </a>
+                       </i>
                        <br/><br/>
                     { this.state.banner_flag_visible &&
                       [<label key="0" className="c-editable-page__label" htmlFor="logoIsBanner">Suppress typeset site name next to logo: </label>,

--- a/app/jsx/layouts/UnitProfileLayout.jsx
+++ b/app/jsx/layouts/UnitProfileLayout.jsx
@@ -210,7 +210,7 @@ class UnitProfileLayout extends React.Component {
                    <br/>
                    { !disableLogo &&
                      <div>
-                       <input type="file" id="logoImage" name="logo" onChange={this.handleImageChange}/>
+                       <input type="file" id="logoImage" name="logo" accept=".png, .jpg, .jpeg, .gif" onChange={this.handleImageChange}/>
                        <br/><br/>
                        <i>Logo requirements: 800px width x 90px height in JPG, PNG, or GIF format. 
                         <a href="https://help.escholarship.org/support/solutions/articles/9000124100">

--- a/app/jsx/layouts/UnitProfileLayout.jsx
+++ b/app/jsx/layouts/UnitProfileLayout.jsx
@@ -148,7 +148,6 @@ class UnitProfileLayout extends React.Component {
 
         imgObj[fieldName] = { imagePreviewUrl: reader.result }
         this.setData(imgObj)
-        this.setState({ banner_flag_visible: true })
       }
     }
 

--- a/app/jsx/layouts/UnitProfileLayout.jsx
+++ b/app/jsx/layouts/UnitProfileLayout.jsx
@@ -63,7 +63,7 @@ class UnitProfileLayout extends React.Component {
   state = { 
     newData: this.props.data,
     banner_flag_visible: this.props.data.logo,
-	tos:this.props.data.tos,
+    tos:this.props.data.tos,
     indexed:"indexed" in this.props.data ? indexOptions.filter(p=>this.props.data["indexed"].includes(p.value)):"",
     disciplines:"disciplines" in this.props.data ? disciplineOptions.filter(p=>this.props.data["disciplines"].includes(p.value)):"",
     contentby:"contentby" in this.props.data ? contentOptions.filter(p=>this.props.data["contentby"].includes(p.value)):"",

--- a/app/jsx/layouts/UnitProfileLayout.jsx
+++ b/app/jsx/layouts/UnitProfileLayout.jsx
@@ -212,11 +212,12 @@ class UnitProfileLayout extends React.Component {
                      <div>
                        <input type="file" id="logoImage" name="logo" accept=".png, .jpg, .jpeg, .gif" onChange={this.handleImageChange}/>
                        <br/><br/>
-                       <i>Logo requirements: 800px width x 90px height in JPG, PNG, or GIF format. 
+                       <div className="upload-criteria">
+                        <span>Logo requirements: 800px width x 90px height in JPG, PNG, or GIF format.&nbsp;</span>
                         <a href="https://help.escholarship.org/support/solutions/articles/9000124100">
                           See the eScholarship help center for more information.
                         </a>
-                       </i>
+                       </div>
                        <br/><br/>
                     { this.state.banner_flag_visible &&
                       [<label key="0" className="c-editable-page__label" htmlFor="logoIsBanner">Suppress typeset site name next to logo: </label>,

--- a/app/jsx/layouts/UnitProfileLayout.jsx
+++ b/app/jsx/layouts/UnitProfileLayout.jsx
@@ -63,7 +63,7 @@ class UnitProfileLayout extends React.Component {
   state = { 
     newData: this.props.data,
     banner_flag_visible: this.props.data.logo,
-	  tos:this.props.data.tos,
+	tos:this.props.data.tos,
     indexed:"indexed" in this.props.data ? indexOptions.filter(p=>this.props.data["indexed"].includes(p.value)):"",
     disciplines:"disciplines" in this.props.data ? disciplineOptions.filter(p=>this.props.data["disciplines"].includes(p.value)):"",
     contentby:"contentby" in this.props.data ? contentOptions.filter(p=>this.props.data["contentby"].includes(p.value)):"",

--- a/app/jsx/layouts/UnitProfileLayout.jsx
+++ b/app/jsx/layouts/UnitProfileLayout.jsx
@@ -107,29 +107,34 @@ class UnitProfileLayout extends React.Component {
   //handles image preview BEFORE any image is POST'ed to server/BEFORE any asset_id is generated
   // TODO: 
   // - accepted dimensions are different for logo and hero -- accomodate both
-  // - dont actually allow user to upload file if it doesnt fit criteria
   handleImageChange = (event) => {
+    event.persist()
     event.preventDefault()
     let reader = new FileReader()
     let file = event.target.files[0]
     let imgObj = {}
-    let fieldName = event.target.name
-
-    // https://stackoverflow.com/a/58897088
-    let img = new Image()
-    console.log(event.target.value)
-    
-    img.src = window.URL.createObjectURL(file)     
-
-    img.onload = () => {
-      if (img.width > MAX_LOGO_WIDTH || img.height > MAX_LOGO_HEIGHT) {
-        alert(`Error: ${img.width}x${img.height} exceeds maximum allowed dimensions of ${MAX_LOGO_WIDTH}x${MAX_LOGO_HEIGHT}`); // change here 
-      }
-    }   
+    let fieldName = event.target.name 
 
     reader.onloadend = () => {
-      imgObj[fieldName] = {imagePreviewUrl: reader.result}
-      this.setData(imgObj)
+      // https://stackoverflow.com/a/58897088
+      let img = new Image()
+      img.src = reader.result
+
+      img.onload = () => {
+        console.log(event.target.value)
+        const { width, height } = img
+        console.log(width, height)
+
+        if (width > MAX_LOGO_WIDTH || height > MAX_LOGO_HEIGHT) {
+          alert(`Error: ${img.width}x${img.height} exceeds maximum allowed dimensions of ${MAX_LOGO_WIDTH}x${MAX_LOGO_HEIGHT}`) // should use ModalComp here
+          event.target.value = "" // reset the filename text
+          return
+        }
+
+        imgObj[fieldName] = { imagePreviewUrl: reader.result }
+        this.setData(imgObj)
+        this.setState({ banner_flag_visible: true })
+      }
     }
 
     reader.readAsDataURL(file)

--- a/app/jsx/layouts/UnitProfileLayout.jsx
+++ b/app/jsx/layouts/UnitProfileLayout.jsx
@@ -9,6 +9,7 @@ import FormComp from '../components/FormComp.jsx'
 import _ from 'lodash'
 import Datetime from 'react-datetime'
 import Select from 'react-select'
+import ModalComp from '../components/ModalComp.jsx'
 
 
 export const contentOptions = [
@@ -44,9 +45,6 @@ export const disciplineOptions = [
     { value: "social", label: "Social and Behavioral Sciences" }
 ];
 
-const MAX_LOGO_WIDTH = 800
-const MAX_LOGO_HEIGHT = 90
-
 const acceptedDimensions = {
   logo: {
     width: 800,
@@ -62,13 +60,16 @@ class UnitProfileLayout extends React.Component {
   // static propTypes = {
   // }
 
-  state = { newData: this.props.data,
-            banner_flag_visible: this.props.data.logo,
-	    tos:this.props.data.tos,
-            indexed:"indexed" in this.props.data ? indexOptions.filter(p=>this.props.data["indexed"].includes(p.value)):"",
-            disciplines:"disciplines" in this.props.data ? disciplineOptions.filter(p=>this.props.data["disciplines"].includes(p.value)):"",
-            contentby:"contentby" in this.props.data ? contentOptions.filter(p=>this.props.data["contentby"].includes(p.value)):"",
-          };
+  state = { 
+    newData: this.props.data,
+    banner_flag_visible: this.props.data.logo,
+	  tos:this.props.data.tos,
+    indexed:"indexed" in this.props.data ? indexOptions.filter(p=>this.props.data["indexed"].includes(p.value)):"",
+    disciplines:"disciplines" in this.props.data ? disciplineOptions.filter(p=>this.props.data["disciplines"].includes(p.value)):"",
+    contentby:"contentby" in this.props.data ? contentOptions.filter(p=>this.props.data["contentby"].includes(p.value)):"",
+    isModalOpen: false,
+    modalContent: ''
+  };
 
   updatetos = value => {
 	  this.setState({ tos: value });
@@ -116,8 +117,6 @@ class UnitProfileLayout extends React.Component {
   }
 
   //handles image preview BEFORE any image is POST'ed to server/BEFORE any asset_id is generated
-  // TODO: 
-  // - accepted dimensions are different for logo and hero -- accomodate both
   handleImageChange = (event) => {
     event.persist() // keep the event from being nullified 
     event.preventDefault()
@@ -135,10 +134,14 @@ class UnitProfileLayout extends React.Component {
 
       img.onload = () => {
         const { width, height } = img
-        console.log(width, height)
 
+        // valid dimension check  
         if (width > acceptedWidth || height > acceptedHeight) {
-          alert(`Error: ${width}x${height} exceeds maximum allowed dimensions of ${acceptedWidth}x${acceptedHeight}`) // should use ModalComp here
+          const errorMessage = `${width}x${height} exceeds maximum allowed dimensions of ${acceptedWidth}x${acceptedHeight}`
+          this.setState({ 
+            isModalOpen: true,
+            modalContent: errorMessage 
+          })
           event.target.value = "" // reset the filename text
           return
         }
@@ -233,6 +236,13 @@ class UnitProfileLayout extends React.Component {
                       }
                      </div>
                    }
+                     <ModalComp
+                       isOpen={this.state.isModalOpen}
+                       header="Upload Error"
+                       content={this.state.modalContent}
+                       onOK={() => this.setState({ isModalOpen: false })}
+                       okLabel="OK"
+                     />
                    <br/>
 
                    { cms.permissions && cms.permissions.super && !disableLogo &&

--- a/app/jsx/layouts/UnitProfileLayout.jsx
+++ b/app/jsx/layouts/UnitProfileLayout.jsx
@@ -47,6 +47,17 @@ export const disciplineOptions = [
 const MAX_LOGO_WIDTH = 800
 const MAX_LOGO_HEIGHT = 90
 
+const acceptedDimensions = {
+  logo: {
+    width: 800,
+    height: 90
+  },
+  hero: {
+    width: 1000,
+    height: 400
+  }
+}
+
 class UnitProfileLayout extends React.Component {
   // static propTypes = {
   // }
@@ -108,12 +119,14 @@ class UnitProfileLayout extends React.Component {
   // TODO: 
   // - accepted dimensions are different for logo and hero -- accomodate both
   handleImageChange = (event) => {
-    event.persist()
+    event.persist() // keep the event from being nullified 
     event.preventDefault()
     let reader = new FileReader()
     let file = event.target.files[0]
     let imgObj = {}
-    let fieldName = event.target.name 
+    let fieldName = event.target.name
+    const acceptedWidth = acceptedDimensions[fieldName].width
+    const acceptedHeight = acceptedDimensions[fieldName].height
 
     reader.onloadend = () => {
       // https://stackoverflow.com/a/58897088
@@ -121,12 +134,11 @@ class UnitProfileLayout extends React.Component {
       img.src = reader.result
 
       img.onload = () => {
-        console.log(event.target.value)
         const { width, height } = img
         console.log(width, height)
 
-        if (width > MAX_LOGO_WIDTH || height > MAX_LOGO_HEIGHT) {
-          alert(`Error: ${img.width}x${img.height} exceeds maximum allowed dimensions of ${MAX_LOGO_WIDTH}x${MAX_LOGO_HEIGHT}`) // should use ModalComp here
+        if (width > acceptedWidth || height > acceptedHeight) {
+          alert(`Error: ${width}x${height} exceeds maximum allowed dimensions of ${acceptedWidth}x${acceptedHeight}`) // should use ModalComp here
           event.target.value = "" // reset the filename text
           return
         }

--- a/app/scss/_editable.scss
+++ b/app/scss/_editable.scss
@@ -87,6 +87,7 @@
 
 .trumbowyg-box, .trumbowyg-editor {
   min-height: 300px;
+  margin-bottom: 20px;
 }
 
 // ### Toggle button used on UnitcarouselConfigComp ### //

--- a/app/scss/_editable.scss
+++ b/app/scss/_editable.scss
@@ -335,3 +335,7 @@
   padding-left: 0.5em;
   margin-left: 0.5em;
 }
+
+.upload-criteria {
+  font-style: italic;
+}


### PR DESCRIPTION
Improvements for #773.

- If the user chooses an image that is not of the appropriate dimensions, we don't allow that image to actually be selected
- Added explanatory text in the UI about size and graphic requirements for the logo, including link to eschol help page
- If there is an issue with the dimensions, the user is notified using our ModalComp (not the browser alert)
- Added supported file types (`.png`, `.jpeg`, `.jpg`, `.gif`), the native file picker will not allow anything else to be selected