### PR TITLE
761 journals are null when units are renamed

### DIFF
--- a/app/jsx/components/FilterComp.jsx
+++ b/app/jsx/components/FilterComp.jsx
@@ -26,7 +26,7 @@ class FilterComp extends React.Component {
       for (let filterType of filterTypes) {
         if (this.props.query['filters'][filterType] && this.props.query['filters'][filterType]['filters'].length > 0) {
           let displayNames = this.props.query['filters'][filterType]['filters'].map(function(filter) {
-            if (filter['displayName'] !== 'null') {
+            if (filter['displayName']) {
               return filter['displayName'];
             } else {
               return filter['value'];

--- a/app/jsx/components/FilterComp.jsx
+++ b/app/jsx/components/FilterComp.jsx
@@ -26,13 +26,18 @@ class FilterComp extends React.Component {
       for (let filterType of filterTypes) {
         if (this.props.query['filters'][filterType] && this.props.query['filters'][filterType]['filters'].length > 0) {
           let displayNames = this.props.query['filters'][filterType]['filters'].map(function(filter) {
-            if ('displayName' in filter) {
+            if (filter['displayName'] !== 'null') {
               return filter['displayName'];
             } else {
               return filter['value'];
             }
           });
-          activeFilters.push({'filterDisplay': this.props.query['filters'][filterType]['display'], 'filters': displayNames.join(", "), 'filterType': filterType});
+          
+          activeFilters.push({
+            'filterDisplay': this.props.query['filters'][filterType]['display'], 
+            'filters': displayNames.join(", "), 
+            'filterType': filterType,  
+          });
         }
       }
     }

--- a/app/jsx/pages/SearchPage.jsx
+++ b/app/jsx/pages/SearchPage.jsx
@@ -112,7 +112,7 @@ class FacetItem extends React.Component {
     let facet = this.props.data.facet
     let facetValueKey = facet.value.replace(/ /g, '_')
     // null in this case is of string type
-    const label = facet.displayName !== 'null' ? facet.displayName : facet.value
+    const label = facet.displayName ? facet.displayName : facet.value
     // Put a special class name on the rights facet to show Creative Commons icons
     let className = this.props.data.facetType == "rights"
                       ? `c-checkbox__attrib-${facet.value.toLowerCase()}`.replace(/ /g, '-')

--- a/app/jsx/pages/SearchPage.jsx
+++ b/app/jsx/pages/SearchPage.jsx
@@ -111,18 +111,29 @@ class FacetItem extends React.Component {
   render() {
     let facet = this.props.data.facet
     let facetValueKey = facet.value.replace(/ /g, '_')
-    this.label = facet.displayName ? facet.displayName : facet.value
+    // null in this case is of string type
+    const label = facet.displayName !== 'null' ? facet.displayName : facet.value
     // Put a special class name on the rights facet to show Creative Commons icons
     let className = this.props.data.facetType == "rights"
                       ? `c-checkbox__attrib-${facet.value.toLowerCase()}`.replace(/ /g, '-')
                       : ""
     return (
       <li className={className}>
-        <input id={`${this.props.data.facetType}-${facetValueKey}`} className="c-checkbox__input" type="checkbox"
-          name={this.props.data.facetType} value={facet.value}
+        <input 
+          id={`${this.props.data.facetType}-${facetValueKey}`} 
+          className="c-checkbox__input" type="checkbox"
+          name={this.props.data.facetType} 
+          value={facet.value}
           onChange={this.handleChange}
-          checked={this.checkFacet(this.props)} disabled={this.props.data.ancestorChecked ? true : false}/>
-        <label htmlFor={`${this.props.data.facetType}-${facetValueKey}`} className="c-checkbox__label">{this.label} ({facet.count})</label>
+          checked={this.checkFacet(this.props)} 
+          disabled={this.props.data.ancestorChecked ? true : false}
+        />
+        <label 
+          htmlFor={`${this.props.data.facetType}-${facetValueKey}`} 
+          className="c-checkbox__label"
+        >
+          {label} ({facet.count})
+        </label>
         { facet.descendents &&
           <ul className="c-checkbox">
             { facet.descendents.map(d => {

--- a/app/jsx/pages/SearchPage.jsx
+++ b/app/jsx/pages/SearchPage.jsx
@@ -111,7 +111,6 @@ class FacetItem extends React.Component {
   render() {
     let facet = this.props.data.facet
     let facetValueKey = facet.value.replace(/ /g, '_')
-    // null in this case is of string type
     const label = facet.displayName ? facet.displayName : facet.value
     // Put a special class name on the rights facet to show Creative Commons icons
     let className = this.props.data.facetType == "rights"

--- a/app/searchApi.rb
+++ b/app/searchApi.rb
@@ -85,7 +85,7 @@ def initAllFacets()
     'displayName' => 'Journal',
     'awsFacetParam' => {sort: 'count', size: 100},
     'filterTransform' => lambda { |filterVals| filterVals.map { |filterVal| {'value' => filterVal, 'displayName' => get_unit_display_name(filterVal)} } },
-    'facetTransform' => lambda { |facetVals| facetVals.map { |facetVal| {'value' => facetVal['value'], 'count' => facetVal['count'], 'displayName' => get_unit_display_name(facetVal['value'])} }.sort_by{ |f| f['displayName'].downcase} }
+    'facetTransform' => lambda { |facetVals| facetVals.map { |facetVal| {'value' => facetVal['value'], 'count' => facetVal['count'], 'displayName' => get_unit_display_name(facetVal['value'])} }.sort_by{ |f| f['displayName']&.downcase || ''} }
   },
   'disciplines' => {
     'displayName' => 'Discipline',
@@ -143,7 +143,7 @@ TYPE_OF_WORK = {
 # takes the code that escholarship UI/AWS uses, returns DisplayName
 def get_unit_display_name(unitID)
   unit = $unitsHash[unitID]
-  unit ? unit.name : "null"
+  unit ? unit.name : nil
 end
 
 # Recursive sort of nested facet array 


### PR DESCRIPTION
Doesn't address the root cause of #761, but ensures that the journal slug is displayed if the name is null.