### PR TITLE
pdf should take up full container width

### DIFF
--- a/app/jsx/components/PdfViewComp.jsx
+++ b/app/jsx/components/PdfViewComp.jsx
@@ -203,7 +203,7 @@ class PdfViewComp extends React.Component {
               <Page
                 key={`page_${index + 1}`}
                 pageNumber={index + 1}
-                width={Math.min(containerWidth, 900)} // use full width, but dont go over 900px
+                width={containerWidth} // resize observed width 
                 inputRef={el => this.pageRefs[index] = el}
               />
             ))}


### PR DESCRIPTION
Removing the `Math.min` reference. There’s a CSS rule in place to prevent the PDF from exceeding the container’s width, and the resize listener adjusts the PDF size according to the viewport width. 