### PR TITLE
811 jschol should properly display links in data availability statement

### DIFF
--- a/app/jsx/components/PubInfoComp.jsx
+++ b/app/jsx/components/PubInfoComp.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import RightsComp from '../components/RightsComp.jsx'
 import PropTypes from 'prop-types'
 
+const default_statement = "No data is associated with this publication."
 class PubInfoComp extends React.Component {
   static propTypes = {
     doi: PropTypes.string,
@@ -16,6 +17,61 @@ class PubInfoComp extends React.Component {
       reason: PropTypes.string,
     }),
     rights: PropTypes.string,
+  }
+
+  // helper to parse URLs (comma/semicolon separated)
+  parseUrls = str => {
+    if (!str) return []
+    // splits on commas/semicolons, removes whitespace, and filters out falsy values 
+    return str.split(/[;,]/).map(url => url.trim()).filter(Boolean)
+  }
+
+  renderStatement = (text, links = []) => {
+    return (
+      <>
+        <div className="c-pubinfo__statement">{text}</div>
+        {links.length > 0 && links.map((url, i) => (
+          <a key={i} className="c-pubinfo__link" href={url}>
+            {url}
+          </a>
+        ))}
+      </>
+    )
+  }
+
+  getStatement = h => {
+    if (!h || !h.type) return this.renderStatement(default_statement)
+  
+    const urlList = this.parseUrls(h.url)
+    const contactList = this.parseUrls(h.contact)
+  
+    const statements = {
+      publicRepo: this.renderStatement(
+        "The data associated with this publication are available at:",
+        urlList
+      ),
+      publicRepoLater: this.renderStatement(
+        "Associated data will be made available after this publication is published."
+      ),
+      suppFiles: this.renderStatement(
+        "The data associated with this publication are in the supplemental files."
+      ),
+      withinManuscript: this.renderStatement(
+        "The data associated with this publication are within the manuscript."
+      ),
+      onRequest: this.renderStatement(
+        "The data associated with this publication are available upon request."
+      ),
+      thirdParty: this.renderStatement(
+        "The data associated with this publication are managed by:",
+        contactList
+      ),
+      notAvail: this.renderStatement(
+        `The data associated with this publication are not available for this reason: ${h.reason}`
+      ),
+    }
+  
+    return statements[h.type] || this.renderStatement(default_statement)
   }
 
   render() {
@@ -34,33 +90,10 @@ class PubInfoComp extends React.Component {
         : null
 
     // ################# Variables for data_avail_stmnt ########################
-    let default_stmnt = <div className="c-pubinfo__statement">No data is associated with this publication.</div>
-    let stmnt = (!this.props.content_type) ? default_stmnt : null 
-    let getStmnt = h => {     // Mimicked from splashGen.rb:getDataAvail()
-      let v = {
-        'publicRepo':      [<div key="0" className="c-pubinfo__statement">
-                              The data associated with this publication are available at:</div>,
-                            <a key="1" className="c-pubinfo__link" href={h["url"]}>{h["url"]}</a>],
-        'publicRepoLater':  <div className="c-pubinfo__statement">
-                              Associated data will be made available after this publication is published</div>,
-        'suppFiles':        <div className="c-pubinfo__statement">
-                              The data associated with this publication are in the supplemental files.</div>,
-        'withinManuscript': <div className="c-pubinfo__statement">
-                              The data associated with this publication are within the manuscript.</div>,
-        'onRequest':        <div className="c-pubinfo__statement">
-                              The data associated with this publication are available upon request.</div>,
-        'thirdParty':       [<div key="0" className="c-pubinfo__statement">
-                              The data associated with this publication are managed by:</div>,
-                              <a className="c-pubinfo__link" href={h["contact"]}>{h["contact"]}</a>],
-        'notAvail':         <div className="c-pubinfo__statement">
-                              The data associated with this publication are not available for this reason: {h["reason"]}</div>,
-        'default':          default_stmnt 
-      }
-      return h["type"] ? v[h["type"]] : v[h["default"]]
-    }
-    if (this.props.data_avail_stmnt) {
-      stmnt = getStmnt(this.props.data_avail_stmnt)
-    }
+    const stmnt = this.props.data_avail_stmnt
+      ? this.getStatement(this.props.data_avail_stmnt)
+      : (!this.props.content_type && this.renderStatement(default_statement))
+    
     return (
       <div className="c-pubinfo">
         {/* all elements below are optional */}

--- a/app/scss/_pubinfo.scss
+++ b/app/scss/_pubinfo.scss
@@ -10,7 +10,6 @@
 
   @include bp(screen1) {
     display: grid;
-    grid-template-columns: 1fr auto;
     grid-gap: $spacing-sm $spacing-md;
 
     > *:not(.c-pubinfo__license) {


### PR DESCRIPTION
Fix for #811. Addresses the two issues listed in the ticket. A quick note:

- For data availability statements with a type of `"thirdParty"`, a corresponding contact property may be provided. This value can either be an entity name (e.g., `"California Air Resources Board, US EPA"`) or one or more URLs. The updated logic handles both cases: if the value contains URLs (starting with "http"), it renders each as an `<a>` link; otherwise, it renders the value as plain text inside a `<span>`.