### PR TITLE
fix cc icon alignment on item pages

### DIFF
--- a/app/jsx/components/PubInfoComp.jsx
+++ b/app/jsx/components/PubInfoComp.jsx
@@ -113,14 +113,18 @@ class PubInfoComp extends React.Component {
     return (
       <div className="c-pubinfo">
         {/* all elements below are optional */}
-      {pub_loc_block &&
-        <h2 className="c-pubinfo__location-heading">Published Web Location</h2>
-      }
-        {pub_loc_block}
-        {stmnt}
-      {this.props.rights &&
-        <RightsComp rights={this.props.rights} size="large" classname="c-pubinfo__license" />
-      }
+        <div className="pub-links-container"> 
+          {pub_loc_block &&
+            <h2 className="c-pubinfo__location-heading">Published Web Location</h2>
+          }
+          {pub_loc_block}
+          {stmnt}
+        </div>
+        {this.props.rights &&
+          <div className="pub-license-container">
+            <RightsComp rights={this.props.rights} size="large" classname="c-pubinfo__license" />
+          </div>
+        }
       </div>
     )
   }

--- a/app/scss/_pubinfo.scss
+++ b/app/scss/_pubinfo.scss
@@ -1,7 +1,8 @@
 // ##### Publication Information Component ##### //
 
 .c-pubinfo {
-  @extend %u-clearfix;
+  display: flex;
+  justify-content: space-between;
   margin-bottom: $spacing-md;
 
   > *:not(.c-pubinfo__license) {
@@ -9,9 +10,6 @@
   }
 
   @include bp(screen1) {
-    display: grid;
-    grid-gap: $spacing-sm $spacing-md;
-
     > *:not(.c-pubinfo__license) {
       margin-bottom: $spacing-sm;
 
@@ -25,8 +23,14 @@
 
 }
 
+.pub-links-container {
+  display: grid;
+  grid-gap: $spacing-sm $spacing-md;
+}
+
 .c-pubinfo__location-heading {
   margin-top: 0;
+  margin-bottom: 0;
   font-size: 1em;
 }
 
@@ -41,26 +45,9 @@
 
 }
 
-.c-pubinfo__statement {
-
-  @include bp(screen1) {
-    grid-column: 1;
-  }
-
-}
-
 .c-pubinfo__license {
-  display: inline-block;
-  margin-left: $spacing-md;
-  float: right;
-
   @supports (display: grid) {
     margin-left: 0;
-  }
-
-  @include bp(screen1) {
-    grid-column: 2;
-    grid-row: 1 / 4;
   }
 
   img {


### PR DESCRIPTION
Fix for #816. Also addresses whitespace issue mentioned in Devin's [ticket](https://github.com/orgs/eScholarship/projects/1/views/1?pane=issue&itemId=118253818).