### PR TITLE
Ext journal updates

### DIFF
--- a/app/jsx/components/TabAuthorComp.jsx
+++ b/app/jsx/components/TabAuthorComp.jsx
@@ -25,12 +25,17 @@ class TabAuthorComp extends React.Component {
         } else {
           voliss = false
         }
-      } else if (numbering === "volume_only") {
-        voliss = "Volume " + vol 
-      } else if (numbering === "issue_only") {
-        voliss = iss 
+      // non-null numbering is unit/issue table data
       } else {
-        voliss = issue_title
+        if (numbering === "volume_only") {
+          voliss = "Volume " + vol 
+        } else if (numbering === "issue_only") {
+          voliss = iss 
+        } else if issue_title {
+          voliss = issue_title
+        } else {
+          voliss = false
+        }
       }
       return voliss 
     }

--- a/app/jsx/components/TabAuthorComp.jsx
+++ b/app/jsx/components/TabAuthorComp.jsx
@@ -12,12 +12,23 @@ class TabAuthorComp extends React.Component {
     }
     else {
       let voliss
+      // null numbering is typically ext_journal data
       if (!numbering) {
-        voliss = iss ? vol + "(" + iss + ")" : vol
+        if (vol && iss) {
+          voliss = vol + "(" + iss + ")"
+        } else if (vol) {
+          voliss = vol
+        } else if (iss) {
+          voliss = iss
+        } else {
+          return issue_title
+        }
       } else if (numbering === "volume_only") {
         voliss = "Volume " + vol 
-      } else {
+      } else if (numbering === "issue_only") {
         voliss = iss 
+      } else {
+        voliss = issue_title
       }
       return voliss 
     }

--- a/app/jsx/components/TabAuthorComp.jsx
+++ b/app/jsx/components/TabAuthorComp.jsx
@@ -20,8 +20,10 @@ class TabAuthorComp extends React.Component {
           voliss = vol
         } else if (iss) {
           voliss = iss
+        } else if (issue_title) {
+          voliss = issue_title
         } else {
-          return issue_title
+          voliss = false
         }
       } else if (numbering === "volume_only") {
         voliss = "Volume " + vol 
@@ -243,8 +245,12 @@ class TabAuthorComp extends React.Component {
     let issue_title = lastCrumb ? lastCrumb.name : null
     let journal_stmnt
     if (journal_name || volume || issue) {
-      let voliss = this.customIssueTitle(volume, issue, p.numbering, issue_title) 
-      journal_stmnt = journal_name ? journal_name+", "+voliss : voliss
+      let voliss = this.customIssueTitle(volume, issue, p.numbering, issue_title)
+      if voliss { 
+        journal_stmnt = journal_name ? journal_name + ", " + voliss : voliss
+      } else {
+        journal_stmnt = false
+      }
     }
 
     let issn = p.attrs['ext_journal'] && p.attrs['ext_journal']['issn']

--- a/app/jsx/components/TabAuthorComp.jsx
+++ b/app/jsx/components/TabAuthorComp.jsx
@@ -127,18 +127,16 @@ class TabAuthorComp extends React.Component {
       let ext = props.attrs.ext_journal
       if (ext && ext.name) {
         // External journals
-        out += "<em>" + ext.name + "</em>, "
+        out += "<em>" + ext.name + "</em>"
         if (ext.volume) {
-          out += ext.volume
-          if (ext.issue)
-            out += "(" + ext.issue + ")"
+          out += ", " + ext.volume
+          if (ext.issue) out += "(" + ext.issue + ")"
+        } else if (ext.issue) {
+          out += ", " + ext.issue
         }
-        else if (ext.issue)
-          out += ext.issue
         if (ext.fpage) {
           out += ", " + ext.fpage
-          if (ext.lpage)
-            out += "-" + ext.lpage
+          if (ext.lpage) out += "-" + ext.lpage
         }
         out = this.addDot(out)
       }


### PR DESCRIPTION
These updates are to handle the new volume- or issue-only data in `items.attrs.ext_journals` specifically in an item's "Author & Article Info" tab --> the text under the "citation" and "Other information" headings.

I've also added a few minor refactors for readability (e.g. adding curly braces to some ambiguous if statements).