### PR TITLE
809 support non journal content from janeway

### DIFF
--- a/app/jsx/components/DrawerComp.jsx
+++ b/app/jsx/components/DrawerComp.jsx
@@ -217,6 +217,7 @@ class DrawerComp extends React.Component {
       { id: "profile",
         title: <Link to={`/uc/${this.props.data.unit.id}/profile`}>
                  {(this.props.data.unit.type === 'journal' && 'Journal Profile') ||
+                  (this.props.data.unit.type === 'conference_proceedings' && 'Proceedings Profile') ||
                   (this.props.data.unit.type.includes('series') && 'Series Profile') ||
                   (this.props.data.unit.type === 'campus' && 'Campus Profile') ||
                   'Unit Profile'}
@@ -236,7 +237,7 @@ class DrawerComp extends React.Component {
       siteSettings.push({ id: "unitBuilder",
                           title: <Link to={`/uc/${this.props.data.unit.id}/unitBuilder`}>Unit Builder</Link>})
     }
-    if (this.props.data.unit.type === 'journal') {
+    if (this.props.data.unit.type === 'journal' || this.props.data.unit.type === 'conference_proceedings') {
       siteSettings.push({ id: "issueConfig", 
                           title: <Link to={`/uc/${this.props.data.unit.id}/issueConfig`}>Issue Configuration</Link>})
     }

--- a/app/jsx/components/Search2Comp.jsx
+++ b/app/jsx/components/Search2Comp.jsx
@@ -49,6 +49,9 @@ class SearchComp2 extends React.Component {
     } else if (this.props.type == "journal") {
       label = "Journal"
       searchUnitType = "journals"
+    } else if (this.props.type == "conference_proceedings") {
+      label = "Proceeding"
+      searchUnitType = "journals" // TODO: update to conference_proceedings
     } else if (this.props.type == "campus") {
       label = "Campus"
       searchUnitType = "campuses"

--- a/app/jsx/layouts/DepartmentLayout.jsx
+++ b/app/jsx/layouts/DepartmentLayout.jsx
@@ -54,6 +54,10 @@ class DepartmentLayout extends React.Component {
         name: PropTypes.string,
         unit_id: PropTypes.string
       })),
+      conference_proceedings: PropTypes.arrayOf(PropTypes.shape({
+        name: PropTypes.string,
+        unit_id: PropTypes.string
+      })),
       related_orus: PropTypes.arrayOf(PropTypes.shape({
         name: PropTypes.string,
         unit_id: PropTypes.string
@@ -106,6 +110,16 @@ class DepartmentLayout extends React.Component {
                 <h3>Journals</h3>
                 <ul>{ data.journals.map((child) =>
                   <li key={child.unit_id}><Link to={"/uc/"+child.unit_id}>{child.name}</Link></li>) } </ul>
+              </div>
+            }
+            {data.conference_proceedings.length > 0 && 
+              <div className="c-unitlist">
+                <h3>Conference Proceedings</h3>
+                <ul>
+                  {data.conference_proceedings.map((child) =>
+                    <li key={child.unit_id}><Link to={"/uc/"+child.unit_id}>{child.name}</Link></li>
+                  )} 
+                </ul>
               </div>
             }
             {data.related_orus.length > 0 &&

--- a/app/jsx/layouts/PublicationLayout.jsx
+++ b/app/jsx/layouts/PublicationLayout.jsx
@@ -8,14 +8,25 @@ import IssueComp from '../components/IssueComp.jsx'
 import PubComp from '../components/PubComp.jsx'
 import IssueActionsComp from '../components/IssueActionsComp.jsx'
 
+const PUBLICATION_CONFIG = {
+  journal: {
+    sidebarTitle: 'Journal Information',
+    defaultMessage: 'This journal\'s first issue is coming soon.'
+  },
+  conference_proceedings: {
+    sidebarTitle: 'Proceedings Information',
+    defaultMessage: 'Conference proceedings are coming soon.'
+  }
+}
+
 class VolumeSelector extends React.Component {
   static propTypes = {
     current_issue_title: PropTypes.string,
     issues: PropTypes.array.isRequired  // [ {:id=>-1, :name=>"Volume 14, Issue 0, 2017",
-                                        // :volume=>"1", :issue=>"2", :published=>#<Date: ...}, ... ]
+    // :volume=>"1", :issue=>"2", :published=>#<Date: ...}, ... ]
   }
 
-  getIssuePath = (unit_id, v,i) => {
+  getIssuePath = (unit_id, v, i) => {
     return `/uc/${unit_id}/${v}/${i}`
   }
 
@@ -32,8 +43,9 @@ class VolumeSelector extends React.Component {
           <summary aria-label="Select a different issue"></summary>
           <div className="o-customselector__menu">
             <ul className="o-customselector__items">
-              {p.issues.map( i => {
-                return (<li key={i.id}><Link to={this.getIssuePath(i.unit_id, i.volume, i.issue)}>{i.name}</Link></li>)})
+              {p.issues.map(i => {
+                return (<li key={i.id}><Link to={this.getIssuePath(i.unit_id, i.volume, i.issue)}>{i.name}</Link></li>)
+              })
               }
             </ul>
           </div>
@@ -74,42 +86,42 @@ class IssueWrapperComp extends React.Component {
   }
 
   render() {
-      let pi = this.props.issue,
-        pi_title = this.props.issues.find(x => x.issue_id === pi.id).name
+    let pi = this.props.issue,
+      pi_title = this.props.issues.find(x => x.issue_id === pi.id).name
     return (
       <section className="o-columnbox1">
         <IssueActionsComp unit_id={pi.unit_id} buy_link={pi.buy_link} />
         {/*              articles={} */}
         <VolumeSelector current_issue_title={pi_title} issues={this.props.issues} />
-      {(pi.cover || pi.title || pi.description) &&
-        <IssueComp cover={pi.cover} title={pi.title} description={pi.description} />
-      }
-    {/* ARTICLE LISTINGS */}
+        {(pi.cover || pi.title || pi.description) &&
+          <IssueComp cover={pi.cover} title={pi.title} description={pi.description} />
+        }
+        {/* ARTICLE LISTINGS */}
         <div>
-      { this.props.display=="magazine" ?
-        pi.sections.map(section =>
-          <div key={section.name}>
-            <h3 className="o-heading1a">{section.name}</h3>
-            <div className="o-dividecontent2x--ruled">
-              {section.articles.map(article => <PubComp h="h4" key={article.id} result={article}/>)}
-            </div>
-          </div>
-        )
-      :
-        pi.sections.map(section =>
-          <div key={section.name}>
-            <h3 className="o-heading1a">{section.name}</h3>
-            {section.articles.map(article => <PubComp h="h4" key={article.id} result={article}/>)}
-          </div>
-        )
-      }
+          {this.props.display == "magazine" ?
+            pi.sections.map(section =>
+              <div key={section.name}>
+                <h3 className="o-heading1a">{section.name}</h3>
+                <div className="o-dividecontent2x--ruled">
+                  {section.articles.map(article => <PubComp h="h4" key={article.id} result={article} />)}
+                </div>
+              </div>
+            )
+            :
+            pi.sections.map(section =>
+              <div key={section.name}>
+                <h3 className="o-heading1a">{section.name}</h3>
+                {section.articles.map(article => <PubComp h="h4" key={article.id} result={article} />)}
+              </div>
+            )
+          }
         </div>
       </section>
     )
   }
 }
 
-class JournalLayout extends React.Component {
+class PublicationLayout extends React.Component {
   static propTypes = {
     unit: PropTypes.shape({
       id: PropTypes.string.isRequired,
@@ -132,36 +144,40 @@ class JournalLayout extends React.Component {
   }
 
   render() {
-    let data = this.props.data
-    let marquee = this.props.marquee
+    const { data, marquee, sidebar } = this.props
+
+    const config = PUBLICATION_CONFIG[unitType]
+
     return (
       <div>
-      {((marquee.carousel && marquee.slides) || marquee.about) &&
-        <MarqueeComp marquee={marquee} />
-      }
+        {((marquee.carousel && marquee.slides) || marquee.about) &&
+          <MarqueeComp marquee={marquee} />
+        }
         <div className="c-columns">
           <main id="maincontent">
 
-          {this.props.data.issue ?
-            <IssueWrapperComp issue={data.issue} issues={data.issuesSubNav} display={data.display} />
-          :
-            <section className="o-columnbox1">
-              <p>This journal's first issue is coming soon.
-              <br/> <br/> <br/> <br/> </p>
-            </section>
-          }
+            {data.issue ?
+              <IssueWrapperComp issue={data.issue} issues={data.issuesSubNav} display={data.display} />
+              :
+              <section className="o-columnbox1">
+                <p>
+                  {config.defaultMessage}
+                  <br /> <br /> <br /> <br /> 
+                </p>
+              </section>
+            }
 
           </main>
           <aside>
-          {(data.doaj || (data.issue && data.issue.rights) || data.issn || data.eissn) &&
-            <section className="o-columnbox1">
-              <header>
-                <h2>Journal Information</h2>
-              </header>
-              <JournalInfoComp doaj={data.doaj} rights={data.issue && data.issue.rights} issn={data.issn} eissn={data.eissn} />
-            </section>
-          }
-            {this.props.sidebar}
+            {(data.doaj || (data.issue && data.issue.rights) || data.issn || data.eissn) &&
+              <section className="o-columnbox1">
+                <header>
+                  <h2>{config.sidebarTitle}</h2>
+                </header>
+                <JournalInfoComp doaj={data.doaj} rights={data.issue && data.issue.rights} issn={data.issn} eissn={data.eissn} />
+              </section>
+            }
+            {sidebar}
           </aside>
         </div>
       </div>
@@ -169,4 +185,4 @@ class JournalLayout extends React.Component {
   }
 }
 
-export default JournalLayout
+export default PublicationLayout

--- a/app/jsx/layouts/PublicationLayout.jsx
+++ b/app/jsx/layouts/PublicationLayout.jsx
@@ -144,8 +144,9 @@ class PublicationLayout extends React.Component {
   }
 
   render() {
-    const { data, marquee, sidebar } = this.props
-
+    const { data, marquee, sidebar, unit } = this.props
+    const unitType = unit.type
+    
     const config = PUBLICATION_CONFIG[unitType]
 
     return (

--- a/app/jsx/layouts/UnitBuilderLayout.jsx
+++ b/app/jsx/layouts/UnitBuilderLayout.jsx
@@ -4,10 +4,13 @@ import FormComp from '../components/FormComp.jsx'
 import { Link } from 'react-router-dom'
 import Contexts from '../contexts.jsx'
 
-const UNIT_TYPE_TO_LABEL = { series: "paper series",
-                             monograph_series: "monograph series",
-                             oru: "ORU",
-                             journal: "journal" }
+const UNIT_TYPE_TO_LABEL = { 
+  series: "paper series",
+  monograph_series: "monograph series",
+  oru: "ORU",
+  journal: "journal",
+  conference_proceedings: "conference proceedings"
+}
 
 class SortableUnitList extends React.Component {
   state = this.setupState(this.props)
@@ -120,8 +123,8 @@ export default class UnitBuilderLayout extends React.Component
 
                   <label className="c-editable-page__label" htmlFor="type">Unit type: </label>
                   <select name="type">
-                    { ["oru", "journal", "series", "monograph_series"].map(unitType =>
-                        <option key={unitType} value={unitType}>{UNIT_TYPE_TO_LABEL[unitType]}</option>) }
+                    { Object.entries(UNIT_TYPE_TO_LABEL).map(unitType =>
+                        <option key={unitType[0]} value={unitType[0]}>{unitType[1]}</option>) }
                   </select>
 
                   <br/><br/>

--- a/app/jsx/layouts/UnitProfileLayout.jsx
+++ b/app/jsx/layouts/UnitProfileLayout.jsx
@@ -291,7 +291,7 @@ class UnitProfileLayout extends React.Component {
                      </div>
                    }
 
-                   { this.props.unit.type == 'journal' &&
+                   { (this.props.unit.type == 'journal' || this.props.unit.type == 'conference_proceedings') &&
                      <div>
                        <br/>
                        { disableEdit ?
@@ -496,7 +496,7 @@ class UnitProfileLayout extends React.Component {
         { this.renderUnitConfig() }
         { this.renderSocialConfig() }
         { this.renderAboutConfig() }
-        { this.props.unit.type == 'journal' && this.renderJournalConfig() }
+        { (this.props.unit.type == 'journal' || this.props.unit.type == 'conference_proceedings') && this.renderJournalConfig() }
       </div>
     )
   }

--- a/app/jsx/pages/UnitPage.jsx
+++ b/app/jsx/pages/UnitPage.jsx
@@ -19,7 +19,7 @@ import BreadcrumbComp from '../components/BreadcrumbComp.jsx'
 import CampusLayout from '../layouts/CampusLayout.jsx'
 import DepartmentLayout from '../layouts/DepartmentLayout.jsx'
 import SeriesLayout from '../layouts/SeriesLayout.jsx'
-import JournalLayout from '../layouts/JournalLayout.jsx'
+import PublicationLayout from '../layouts/PublicationLayout.jsx'
 import UnitSearchLayout from '../layouts/UnitSearchLayout.jsx'
 import UnitStaticPageLayout from '../layouts/UnitStaticPageLayout.jsx'
 import UnitProfileLayout from '../layouts/UnitProfileLayout.jsx'
@@ -123,7 +123,9 @@ class UnitPage extends PageBase {
       else if (data.unit.type.includes('series'))
         contentLayout = <SeriesLayout unit={data.unit} data={data.content} sidebar={sidebar} marquee={data.marquee}/>
       else if (data.unit.type === 'journal')
-        contentLayout = <JournalLayout unit={data.unit} data={data.content} sidebar={sidebar} marquee={data.marquee}/>
+        contentLayout = <PublicationLayout unit={data.unit} data={data.content} sidebar={sidebar} marquee={data.marquee}/>
+      else if (data.unit.type === 'conference_proceedings')
+        contentLayout = <PublicationLayout unit={data.unit} data={data.content} sidebar={sidebar} marquee={data.marquee}/>
       else
         contentLayout = <ServerErrorComp error="Not Found"/>
     }

--- a/app/searchApi.rb
+++ b/app/searchApi.rb
@@ -25,6 +25,8 @@ $csClient = Aws::CloudSearchDomain::Client.new(
 # search would need to be modified to understand what to do without a query parameter (matchall & structured)
 # search would also need to be modified to not necessarily do all the results handling
 
+# TODO: do conference proceedings need their own facet?
+
 ITEM_SPECIFIC = ['type_of_work', 'peer_reviewed', 'supp_file_types', 'pub_year', 'disciplines', 'rights']
 $allFacets = nil
 
@@ -419,6 +421,8 @@ def extent(id, type)
     filter = "(term field=departments '#{id}')"
   elsif (type == 'journal') then
     filter = "(term field=journals '#{id}')"
+  elsif (type == 'conference_proceedings') then
+    filter = "(term field=journals '#{id}')" # TODO: update this to be field=conference_proceedings
   elsif (type == 'campus') then
     filter = "(term field=campuses '#{id}')"
   elsif (type == 'series' || type == 'monograph_series' || type == 'seminar_series') then

--- a/app/server.rb
+++ b/app/server.rb
@@ -1074,7 +1074,7 @@ def getUnitPageData(unitID, pageName, subPage)
 
     issuesSubNav, issueIds, issuesPublished, journalIssue = nil, nil, nil, nil
     # Gather header data
-    if unit.type == 'journal'
+    if unit.type == 'journal' || unit.type == 'conference_proceedings'
       issueIds = getIssueIds(unit)
       issuesPublished = (issueIds && issueIds.any?) ? getPublishedJournalIssues(issueIds) : nil
       issuesSubNav = getIssuesSubNav(issuesPublished)
@@ -1126,7 +1126,7 @@ def getUnitPageData(unitID, pageName, subPage)
     else
       pageData[:content] = getUnitStaticPage(unit, attrs, pageName)
     end
-    pageData[:marquee] = getUnitMarquee(unit, attrs) if (["home", "search"].include? pageName or unit.type == 'journal')
+    pageData[:marquee] = getUnitMarquee(unit, attrs) if (["home", "search"].include? pageName or unit.type == 'journal' or unit.type == 'conference_proceedings')
   else
     #public API data
     pageData = {

--- a/app/unitPages.rb
+++ b/app/unitPages.rb
@@ -1128,7 +1128,7 @@ put "/api/unit/:unitID/unitBuilder" do |parentUnitID|
   unitName.nil? || unitName.empty? and jsonHalt(400, "Invalid unit name")
 
   unitType = params[:type]
-  %w{oru journal series monograph_series}.include?(unitType) or jsonHalt(400, "Invalid unit type")
+  %w{oru journal series monograph_series conference_proceedings}.include?(unitType) or jsonHalt(400, "Invalid unit type")
 
   isHidden = !!params[:hidden]
 

--- a/app/unitPages.rb
+++ b/app/unitPages.rb
@@ -211,8 +211,16 @@ def getNavBar(unit, navItems, level=1, issuesSubNav=nil)
                           "name"=>getIssueDropDownName(unit, issuesSubNav),
                           "url"=>nil, "sub_nav"=>issuesSubNav })
       end
+      home_name = case unit.type
+                  when "journal"
+                    "Journal Home"
+                  when "conference_proceedings"  
+                    "Proceedings Home"
+                  else 
+                    "Unit Home"
+                  end
       navItems.unshift({ "id"=>-9999, "type"=>"fixed_page",
-                         "name"=>unit.type == "journal" ? "Journal Home" : "Unit Home",
+                         "name"=>home_name,
                          "url"=>"/uc/#{unitID}" })
     end
     return navItems

--- a/app/unitPages.rb
+++ b/app/unitPages.rb
@@ -404,6 +404,7 @@ def getORULandingPageData(id)
     :series => children ? children.select { |u| u.unit.type == 'series' }.map { |u| seriesPreview(u) }.sort_by{|u| u[:ordering]} : [],
     :monograph_series => children ? children.select { |u| u.unit.type == 'monograph_series' }.map { |u| seriesPreview(u) } : [],
     :journals => children ? children.select { |u| u.unit.type == 'journal' }.map { |u| {unit_id: u.unit_id, name: u.unit.name} } : [],
+    :conference_proceedings => children ? children.select { |u| u.unit.type == 'conference_proceedings' }.map { |u| {unit_id: u.unit_id, name: u.unit.name} } : [],
     :related_orus => related_orus 
   }
 end

--- a/app/unitPages.rb
+++ b/app/unitPages.rb
@@ -251,7 +251,7 @@ end
 
 # Returns array of a journal issue's IDs, only for published issues
 def getIssueIds (unit)
-  if unit.type == 'journal'
+  if unit.type == 'journal' || unit.type == 'conference_proceedings'
     return Issue.distinct.select(Sequel[:issues][:id]).
       join(:sections, issue_id: :id).
       join(:items, section: Sequel[:sections][:id]).
@@ -342,7 +342,7 @@ def getUnitPageContent(unit:, attrs:, query:, issueIds:, issuesPublished:)
     return getCampusLandingPageData(unit, attrs)
   elsif unit.type.include? 'series'
     return getSeriesLandingPageData(unit, query)
-  elsif unit.type == 'journal'
+  elsif unit.type == 'journal' || unit.type == 'conference_proceedings'
     return getJournalIssueData(unit, attrs, issueIds, issuesPublished)
   else
     # ToDo: handle 'special' type here
@@ -634,6 +634,9 @@ def unitSearch(params, unit)
   elsif unit.type == 'journal'
     resultsListFields = ['thumbnail', 'pub_year', 'publication_information']
     params["journals"] = [unit.id]
+  elsif unit.type == 'conference_proceedings'
+    resultsListFields = ['thumbnail', 'pub_year', 'publication_information']
+    params["journals"] = [unit.id]
   elsif unit.type == 'campus'
     resultsListFields = ['thumbnail', 'pub_year', 'publication_information', 'type_of_work', 'rights', 'peer_reviewed']
     params["campuses"] = [unit.id]
@@ -693,7 +696,7 @@ def getUnitProfile(unit, attrs)
   attrs['directManageURLauthor'] and profile[:directManageURLauthor] = attrs['directManageURLauthor']
   attrs['directManageURLeditor'] and profile[:directManageURLeditor] = attrs['directManageURLeditor']
   attrs['elements_id'] and profile[:elementsID] = attrs['elements_id']
-  if unit.type == 'journal'
+  if unit.type == 'journal' || unit.type == 'conference_proceedings'
     profile[:doaj] = attrs['doaj']
     profile[:issn] = attrs['issn']
     profile[:eissn] = attrs['eissn']
@@ -709,7 +712,7 @@ def getUnitProfile(unit, attrs)
     profile[:apc] = attrs['apc'] || ''
     profile[:contentby] = attrs['contentby'] || []
   end
-  if unit.type =~ /series|journal/
+  if unit.type =~ /series|journal|conference_proceedings/
     profile[:commenting_ok] = attrs['commenting_ok']
   end
   if unit.type == 'oru'
@@ -1135,7 +1138,7 @@ put "/api/unit/:unitID/unitBuilder" do |parentUnitID|
   # Add a basic nav bar. Fixed/immovable nav buttons "__ Home" (and "Issues" dropdown for journals) will be included in the nav by default (called up when page is being rendered)
   attrs = {
     about: "About #{unitName}: TODO",
-    nav_bar: %w{oru journal}.include?(unitType) ? [
+    nav_bar: %w{oru journal conference_proceedings}.include?(unitType) ? [
       { id: 1, name: "About", slug: "about", type: "page" },
       { id: 2, name: "Contact us", slug: "contact", type: "page" }
     ] : []
@@ -1148,7 +1151,7 @@ put "/api/unit/:unitID/unitBuilder" do |parentUnitID|
                 status: isHidden ? "hidden" : "active",
                 attrs: attrs.to_json)
 
-    if %w{oru journal}.include?(unitType)
+    if %w{oru journal conference_proceedings}.include?(unitType)
       Page.create(unit_id: newUnitID,
                   name: "About",
                   title: "About #{unitName}",


### PR DESCRIPTION
First pass for #809. Users can create a conference proceeding unit type, with additional unit types to be introduced in the future. These unit types are still considered `journals` in regards to search functionality. The cloudsearch schema needs to be updated with a `conference_proceedings` facet in order to support this. 