### PR TITLE
851 improve accessbility of escholarship video player

### DIFF
--- a/app/jsx/objects/MediaFeatureObj.jsx
+++ b/app/jsx/objects/MediaFeatureObj.jsx
@@ -29,9 +29,9 @@ class MediaFeatureObj extends React.Component {
               {trackFiles.length > 0 && trackFiles.map((track, index) => (
                 <track 
                   key={track.file}
-                  kind="captions" 
+                  kind="subtitles" 
                   src={track.url} 
-                  srcLang="en"
+                  srcLang={track.language}
                   label={`Captions ${index + 1}`}
                   default={index === 0}
                 />


### PR DESCRIPTION
Fix for #851. When uploading separate track (VTT) files, they must adhere to the `filename.language.vtt` format. For example, if the video file is named `video.mp4`, the corresponding VTT file should be named `video.en.vtt`.