### PR TITLE
update data prefix in socks proxying to match new MySQL version reqs

### DIFF
--- a/app/socksMysql.rb
+++ b/app/socksMysql.rb
@@ -65,7 +65,7 @@ class SocksMysql
           # WARNING: this sequence is specific to the version of MySQL you are using...
           # and will likely change after any major upgrade of MySQL
 
-          !data.start_with? "J\x00\x00\x00" and data = "J\x00\x00\x00" + data
+          !data.start_with? "I\x00\x00\x00" and data = "I\x00\x00\x00" + data
           # puts "Tranferring data from #{r == localSock ? "local" : r == remoteSock ? "remote" : r}: #{data.inspect}"
           first = false
         end


### PR DESCRIPTION
The fix involved changing the ASCII code for the first byte of the handshake packet, which changed between MySQL 8.0 -> 8.4. 

- If the first bytes are wrong, the client and server can't negotiate the protocol, resulting in the `protocol mismatch` error.