### PR TITLE
extend logic for conference proceeding units

### DIFF
--- a/app/jsx/components/TabAuthorComp.jsx
+++ b/app/jsx/components/TabAuthorComp.jsx
@@ -147,8 +147,8 @@ class TabAuthorComp extends React.Component {
         }
         out = this.addDot(out)
       }
-      else if (props.unit.type == "journal" && props.citation) {
-        // Internal (escholarship) journals
+      else if ((props.unit.type == "journal" || props.unit.type == "conference_proceedings") && props.citation) {
+        // Internal (escholarship) journals and conference proceedings
         out += "<em>" + props.unit.name + "</em>"
         let voliss = ""
         if (props.numbering == "issue_only")
@@ -261,7 +261,15 @@ class TabAuthorComp extends React.Component {
     let issn = p.attrs['ext_journal'] && p.attrs['ext_journal']['issn']
 
     let unit_type
-    if (p.unit) { unit_type = p.unit.type == 'journal' ? "Journal" : "Series" }
+    if (p.unit) {
+      if (p.unit.type === 'journal') {
+        unit_type = "Journal"
+      } else if (p.unit.type === 'conference_proceedings') {
+        unit_type = "Conference Proceedings"
+      } else {
+        unit_type = "Series"
+      }
+    }
 
     let permalink = "https://escholarship.org/uc/item/" + p.id
     let appearsIn = p.appearsIn.map(function(node, i) {
@@ -394,7 +402,7 @@ class TabAuthorComp extends React.Component {
           }
 
           {journal_stmnt && 
-            [<dt key="0"><strong>Journal Issue:</strong></dt>,
+            [<dt key="0"><strong>{p.unit && p.unit.type === 'conference_proceedings' ? 'Conference Proceedings Issue:' : 'Journal Issue:'}</strong></dt>,
              <dd key="1">
              {issue_url ?
                <Link to={issue_url} className="o-textlink__secondary">{journal_stmnt}</Link>

--- a/app/jsx/pages/ItemPage.jsx
+++ b/app/jsx/pages/ItemPage.jsx
@@ -135,7 +135,7 @@ class ItemPage extends PageBase {
     let descr_editors = d.editors ? "Editor(s): " + d.editors.slice(0, 85).map((editor) => { return editor.name }).join('; ') : ""
     let descr_advisors = d.advisors ? "Advisor(s): " + d.advisors.slice(0, 85).map((advisor) => { return advisor.name }).join('; ') : ""
     let contribs = [descr_authors, descr_editors, descr_advisors].filter(e => e !== '').join(' | ')
-    let journal_title = (d.unit && (d.unit.type == 'journal')) ?
+    let journal_title = (d.unit && (d.unit.type == 'journal' || d.unit.type == 'conference_proceedings')) ?
       <meta id="meta-journal_title" name="citation_journal_title" content={d.unit.name} /> : null
     let [issn, volume, issue, firstpage, lastpage] = [null, null, null, null, null]
     if (a['ext_journal']) {

--- a/app/server.rb
+++ b/app/server.rb
@@ -1250,10 +1250,7 @@ def getItemPageData(shortArk)
       if unit
         unit_attrs = JSON.parse(unit[:attrs])
         body[:unit_attrs] = unit_attrs               # Strictly used for admin reference
-        if unit.type != 'journal'
-          body[:header] = getUnitHeader(unit)
-          body[:altmetrics_ok] = true
-        else 
+        if unit.type == 'journal' || unit.type == 'conference_proceedings'
           body[:altmetrics_ok] = unit_attrs['altmetrics_ok']
           issue_id = Item.join(:sections, :id => :section).filter(Sequel.qualify("items", "id") => id).map(:issue_id)[0]
           if issue_id
@@ -1271,6 +1268,9 @@ def getItemPageData(shortArk)
           else
             body[:header] = getUnitHeader(unit, nil, nil)
           end
+        else
+          body[:header] = getUnitHeader(unit)
+          body[:altmetrics_ok] = true
         end
         body[:commenting_ok] = unit_attrs['commenting_ok'] && item.status == 'published'
       end

--- a/app/unitPages.rb
+++ b/app/unitPages.rb
@@ -206,7 +206,7 @@ def getNavBar(unit, navItems, level=1, issuesSubNav=nil)
     }
     if level==1 && !isTopmostUnit(unit)
       unitID = unit.type.include?('series') ? getUnitAncestor(unit).id : unit.id
-      if unit.type == "journal" && issuesSubNav && issuesSubNav.length > 0
+      if (unit.type == "journal" || unit.type == "conference_proceedings") && issuesSubNav && issuesSubNav.length > 0
         navItems.unshift({ "id"=>0, "type"=>"fixed_folder",
                           "name"=>getIssueDropDownName(unit, issuesSubNav),
                           "url"=>nil, "sub_nav"=>issuesSubNav })


### PR DESCRIPTION
More updates for #809. In addition to fixes in other repos ([eschol API](https://github.com/eScholarship/escholApi/pull/95), [convert](https://github.com/eScholarship/jschol-tools/pull/9)), also resolves #879. This PR specifically addresses some areas I overlooked in `server.rb` and `unitPages.rb` where the new unit type logic should have been applied. The breadcrumbs and issues dropdown now correctly render on item pages and unit nav bars, respectively. 