### PR TITLE
added OSTI ID to local labels on tab author comp

### DIFF
--- a/app/jsx/components/TabAuthorComp.jsx
+++ b/app/jsx/components/TabAuthorComp.jsx
@@ -52,6 +52,7 @@ class TabAuthorComp extends React.Component {
       'lbnl':         "LBNL Report #: ",
       'merritt':      "Merritt ID: ",
       'oa_harvester': "UCPMS ID: ",
+      'osti_id':      "OSTI ID: ",
       'other':        "",
       'pmid':         "Pubmed ID: ",
       'pmcid':        "PubMed Central ID: ",


### PR DESCRIPTION
One-line change: Adding customized labels for OSTI IDs in the "Author & Article info" tab