### PR TITLE
updating robots to align with current ip request threshold

### DIFF
--- a/app/server.rb
+++ b/app/server.rb
@@ -392,10 +392,12 @@ get "/robots.txt" do
            "",
            "User-agent: *",
            "Disallow: /search",
-           "Disallow:#{request.host == "escholarship.org" ? "" : " /"}",
+           "Disallow: /search/",
+           "Disallow: /search*",
+           "#{request.host == "escholarship.org" ? "" : "Disallow: /"}",
            "",
            "User-agent: *",
-           "Crawl-delay: 4",
+           "Crawl-delay: 10",
            "",
            "Sitemap: #{request.env['HTTP_CLOUDFRONT_FORWARDED_PROTO'] || request.scheme}://#{request.host}/siteMapIndex.xml"]
   return lines.join("\n")


### PR DESCRIPTION
- Covering all the bases for dissalowing `/search`
- Bumping up the crawl-delay to fall below our IP-rate limiting threshold (this is currently set to 10/1min, e.g. 6 seconds, but 10 will ensure ensure they don't go over if our http replies are a little delayed.)