### PR TITLE
Added keep alive for OJS DB

### DIFF
--- a/app/dbCache.rb
+++ b/app/dbCache.rb
@@ -237,6 +237,9 @@ def fillCaches
   $cacheFillMutex.synchronize {
     begin
       $lastFillTime = Time.now
+      puts "Keep OJS connection alive"
+      row = OJS_DB[:sessions].first
+      puts row.inspect
       puts "Filling caches started. fill time is #{$lastFillTime}          "
       $unitsHash = getUnitsHash
       $hierByUnit = getHierByUnit

--- a/app/server.rb
+++ b/app/server.rb
@@ -82,10 +82,7 @@ def ensureConnect(envPrefix)
                "charset"  => 'utf8mb4',
                "reconnect"      => true,
                "max_connections"=> 10,
-               "pool_timeout"   => 5
-
-
-  }
+               "pool_timeout"   => 5}
   if ENV['USE_SOCKS_FOR_MYSQL'].to_s.downcase == 'true'
     if TCPSocket::socks_port
       SocksMysql.new(dbConfig)

--- a/app/server.rb
+++ b/app/server.rb
@@ -79,16 +79,17 @@ def ensureConnect(envPrefix)
                "database" => getEnv("#{envPrefix}_DATABASE"),
                "username" => getEnv("#{envPrefix}_USERNAME"),
                "password" => getEnv("#{envPrefix}_PASSWORD"),
-               "charset"  => 'utf8mb4',
-               "reconnect"      => true,
-               "max_connections"=> 10,
-               "pool_timeout"   => 5}
+               "charset"  => 'utf8mb4'}
+
+  if envPrefix == "OJS_DB"
+      dbConfig["test"] = true
+  end
   if ENV['USE_SOCKS_FOR_MYSQL'].to_s.downcase == 'true'
     if TCPSocket::socks_port
       SocksMysql.new(dbConfig)
     end
   end
-  db = Sequel.connect(dbConfig.merge(test: true))
+  db = Sequel.connect(dbConfig)
   n = db.fetch("SHOW TABLE STATUS").all.length
   n > 0 or raise("Failed to connect to db.")
   return db

--- a/app/server.rb
+++ b/app/server.rb
@@ -80,10 +80,6 @@ def ensureConnect(envPrefix)
                "username" => getEnv("#{envPrefix}_USERNAME"),
                "password" => getEnv("#{envPrefix}_PASSWORD"),
                "charset"  => 'utf8mb4' }
-
-  if envPrefix == "OJS_DB"
-      dbConfig["test"] = true
-  end
   if ENV['USE_SOCKS_FOR_MYSQL'].to_s.downcase == 'true'
     if TCPSocket::socks_port
       SocksMysql.new(dbConfig)

--- a/app/server.rb
+++ b/app/server.rb
@@ -79,7 +79,7 @@ def ensureConnect(envPrefix)
                "database" => getEnv("#{envPrefix}_DATABASE"),
                "username" => getEnv("#{envPrefix}_USERNAME"),
                "password" => getEnv("#{envPrefix}_PASSWORD"),
-               "charset"  => 'utf8mb4'}
+               "charset"  => 'utf8mb4' }
 
   if envPrefix == "OJS_DB"
       dbConfig["test"] = true

--- a/app/server.rb
+++ b/app/server.rb
@@ -79,13 +79,19 @@ def ensureConnect(envPrefix)
                "database" => getEnv("#{envPrefix}_DATABASE"),
                "username" => getEnv("#{envPrefix}_USERNAME"),
                "password" => getEnv("#{envPrefix}_PASSWORD"),
-               "charset"  => 'utf8mb4' }
+               "charset"  => 'utf8mb4',
+               "reconnect"      => true,
+               "max_connections"=> 10,
+               "pool_timeout"   => 5
+
+
+  }
   if ENV['USE_SOCKS_FOR_MYSQL'].to_s.downcase == 'true'
     if TCPSocket::socks_port
       SocksMysql.new(dbConfig)
     end
   end
-  db = Sequel.connect(dbConfig)
+  db = Sequel.connect(dbConfig.merge(test: true))
   n = db.fetch("SHOW TABLE STATUS").all.length
   n > 0 or raise("Failed to connect to db.")
   return db


### PR DESCRIPTION
Added reconnect to config as well as test flag to validate connection. 
Call stack for the OJS DB failure after instance idle is in the issue:
https://github.com/eScholarship/jschol/issues/951 