### PR TITLE
adding preload_app! false to pumakiller.rb

### DIFF
--- a/config/pumakiller.rb
+++ b/config/pumakiller.rb
@@ -1,3 +1,7 @@
+# Puma v7+ requires explicitly setting repload_app! 
+# False: Prevents sharing application code in memory (which requires DB connection mgmt)
+preload_app! false
+
 worker_timeout 120 # the default of 60 is usually hit on first startup, since this is a dev instance, we can wait
 worker_shutdown_timeout 90  # HTTP timeout is usually 60 sec, so give extra to be sure we don't drop any
 


### PR DESCRIPTION
- This change is needed for puma v7+
- Without this, by default resources are shared between workers after terminate/new via worker kill, including database connections.
   - And without explicitly managing DB connections during this process, the connection is broken, resulting in errors when workers try to connect to (e.g.) the eSchol DB for stats, or the OJS DB for login.
- This change was tested on staging and prod, and is working as expected.
   - However, if the resource-sharing is creating performance issues on jSchol, an alternate strategy is to explicitly handle the DB connection mgmt during the puma WorkerKill process. This would likely occur in the kill/start code in `pumakiller.rb`