### PR TITLE
PDF viewer: fix jump links for 'custom' toc; performance improvements 

### DIFF
--- a/app/jsx/components/JumpComp.jsx
+++ b/app/jsx/components/JumpComp.jsx
@@ -47,7 +47,7 @@ class JumpComp extends React.Component {
               { toc &&
                 toc.map(item =>
                   <li key={item.title}>
-                   <Link to="#" onClick={(e)=>this.handleClick(e, item.anchor)}>{item.title}</Link>
+                   <Link to="#" onClick={(e)=>this.handleClick(e, item.anchor || `page=${item.page}`)}>{item.title}</Link>
                   </li>
                 )
               }

--- a/app/jsx/components/PdfViewComp.jsx
+++ b/app/jsx/components/PdfViewComp.jsx
@@ -107,30 +107,28 @@ class PdfViewComp extends React.Component {
   }
 
   onLoadSuccess = ({ numPages }) => {
-    // ensure that scrolling happens AFTER document has loaded
-    this.setState({ numPages }, () => {
-      this.scrollToPageNum()
-    })
+    this.setState({ numPages }, () => this.scrollToPageNum())
   }
 
-  // respond to pageNum updates coming from parent props (user clicks toc item or hash changes)
   componentDidUpdate(prevProps) {
-    if (prevProps.pageNum !== this.props.pageNum) {
-      this.scrollToPageNum()
-    }
+    // a new target page (toc click/hash change)
+    const pageChanged = prevProps.pageNum !== this.props.pageNum
+    // Main tab stays mounted while hidden, so its resize observer reports ~0 width
+    // Wait for the real width after reveal before scrolling
+    const revealed = prevProps.containerWidth <= 1 && this.props.containerWidth > 1
+
+    if (this.props.pageNum && this.props.containerWidth > 1 && (pageChanged || revealed))
+      this.scrollToPageNum(revealed ? 500 : 200)
   }
 
-  scrollToPageNum = () => {
+  scrollToPageNum = (delay = 200) => {
     if (this.scrollTimeout) clearTimeout(this.scrollTimeout)
-  
+
     const pageRef = this.pageRefs?.[this.props.pageNum - 1]
-    if (pageRef) {
-      this.scrollTimeout = setTimeout(() => {
-        pageRef.scrollIntoView({ behavior: "smooth" })
-      }, 200)
-    }
+    if (pageRef)
+      this.scrollTimeout = setTimeout(() => pageRef.scrollIntoView({ behavior: "smooth" }), delay)
   }
-  
+
   componentWillUnmount() {
     if (this.scrollTimeout) clearTimeout(this.scrollTimeout)
   }
@@ -151,11 +149,11 @@ class PdfViewComp extends React.Component {
     </a>
   )
 
-  // Make a best effort to avoid re-initting pdf.js, which loses page context
+  // Skip re-renders on unrelated parent updates (e.g. tab switches)
+  // only re-render when the PDF, its size, or the target page changes
   shouldComponentUpdate(nextProps, nextState) {
     return (
       this.props.url !== nextProps.url ||
-      // we want the component to re-render if there's state changes (numPages)
       this.state.numPages !== nextState.numPages ||
       this.props.containerWidth !== nextProps.containerWidth ||
       this.props.pageNum !== nextProps.pageNum

--- a/app/jsx/components/TabsComp.jsx
+++ b/app/jsx/components/TabsComp.jsx
@@ -79,7 +79,8 @@ class TabsComp extends React.Component {
         </div>
         <div className="c-tabs__content" ref={this.tabContentRef} tabIndex="-1">
           {/* 'tab_anchors' are defined in ItemPage component */}
-          {p.currentTab == "main"         && <TabMainComp {...p} />}
+          {/* Keep the main tab mounted (hidden when inactive) so the PDF doesn't re-init every time */}
+          <div hidden={p.currentTab != "main"}><TabMainComp {...p} /></div>
           {p.currentTab == "supplemental" && <TabSupplementalComp {...p} />}
           {p.currentTab == "metrics"      && <TabMetricsComp {...p} />}
           {p.currentTab == "author"       && <TabAuthorComp {...p} />}

--- a/app/jsx/pages/ItemPage.jsx
+++ b/app/jsx/pages/ItemPage.jsx
@@ -48,16 +48,12 @@ class ItemPage extends PageBase {
   }
 
   // currentTab should be 'main' whenever hash starts with 'article_" (or is empty)
-  articleHashHandler = (h, toc) => {
-    if (/^article|^$/.test(h))
+  articleHashHandler = (url_hash, toc) => {
+    if (/^article|^$/.test(url_hash))
       return "main"
-    if (toc) {
-      for (let i in toc.divs) {
-        if (h == toc.divs[i].anchor)
-          return "main"
-      }
-    }
-    return h
+    if (toc?.divs?.some(div => url_hash == (div.anchor || `page=${div.page}`)))
+      return "main"
+    return url_hash
   }
 
   componentDidMount(...args) {
@@ -105,25 +101,16 @@ class ItemPage extends PageBase {
     }
   }
 
+  // handles active navigation (tab buttons and jump links)
   changeTab = tabName => {
-    let toc = this.state.pageData && this.state.pageData.attrs && this.state.pageData.attrs.toc
+    if (!tabName) return
 
-    if (toc) {
-      const pageNumber = parseInt(tabName.split('=')[1], 10)
-      this.setState({ pageNum: pageNumber })
-    }
+    // pushState avoids native hash-navigation stealing focus/scroll
+    history.pushState(null, '', `#${tabName}`)
+    this.handleHashChange()
 
-    let newTab = this.articleHashHandler(tabName.toLowerCase().replace(/^#/, ""), toc)
-
-    if (newTab != this.state.currentTab) {
-      this.setState({currentTab: this.articleHashHandler(tabName, toc) })
-      // Update the URL hash for deep linking, using pushState avoids the browser's
-      // native hash-navigation behavior which would steal focus/scroll 
-      // e.g. #main matches the root <div id="main"> and jumps to the top of the page
-      setTimeout(() => history.pushState(null, '', `#${tabName}`), 200)
-    } else {
-      history.pushState(null, '', `#${tabName}`)
-    }
+    // Scroll once the tab's anchor exists in the DOM
+    setTimeout(() => document.getElementsByName(tabName)[0]?.scrollIntoView(), 0)
   }
 
   renderData = data => {


### PR DESCRIPTION
While working on ToC regeneration, I noticed that previous changes to the PDF viewer had broken jump links whose source is `custom` (e.g. [4qf1c74d](https://escholarship.org/uc/item/4qf1c74d)). Their data shape differs slightly, so this fix normalizes it. I also made a couple of small performance improvements to prevent pdf.js from unnecessarily re-initializing the PDF when switching tabs on the item page.
